### PR TITLE
Docker container to check compatibility with PHP versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM php:5.6-cli
+ARG PHP_VERSION=7.4
+FROM php:${PHP_VERSION}-cli
 
 WORKDIR /usr/src/app/
 
 COPY composer-install.sh /usr/src/app/
 
 RUN apt-get update
-RUN apt-get install wget
+RUN apt-get install wget -y
+RUN apt-get install zip -y
+RUN apt-get install git -y
+RUN apt autoremove -y
 RUN ./composer-install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:5.6-cli
+
+WORKDIR /usr/src/app/
+
+COPY composer-install.sh /usr/src/app/
+
+RUN apt-get update
+RUN apt-get install wget
+RUN ./composer-install.sh

--- a/composer-install.sh
+++ b/composer-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/composer-install.sh
+++ b/composer-install.sh
@@ -11,7 +11,7 @@ then
     exit 1
 fi
 
-php composer-setup.php --quiet
+php composer-setup.php --quiet --install-dir=/usr/local/bin/ --filename=composer
 RESULT=$?
 rm composer-setup.php
 exit $RESULT


### PR DESCRIPTION
## Changes

This is a very basic approach to test the plugin with various PHP versions. 

## Usage

From `wp-notify` root folder:

```bash
docker build -t wp-notify .
```

[Update]
Optionaly, you can specify a PHP version. You should then use a specific tag so you can have as much different images as you want (default: latest patch of 7.4). Example:

```bash
docker build -t wp-notify:5.6 . --build-arg PHP_VERSION=5.6
```

Then install the dependencies with the composer provided inside the container (use the same name that you passed as argument of the `-t` option). Example:
 
```bash
docker run --rm --volume /path/to/wp-notify:/usr/src/app wp-notify:5.6 composer install
```

Then you can run the unit tests inside the container:

```bash
docker run --rm --volume /path/to/wp-notify:/usr/src/app wp-notify:5.6 vendor/bin/phpunit
```

_Notes_: 
- The `wp-notify` name can be set to whichever name you want for your docker image. Remember to use the same name for the `build` and `run` command.
[Update]
- You can try with different version of PHP, use the version number referenced on [this page](https://github.com/docker-library/docs/tree/master/php#supported-tags-and-respective-dockerfile-links), but don't put the `-` separated part like `-alpine` or `-cli`.
- PHP version 8 is available, however, the actual version of PHPUnit is not compatible with it.
- The files are actually stored on your filesystem, thanks to the path to the `wp-notify` project you provided to the `--volume` option (use absolute path).