### PR TITLE
Adding initial database schema

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -5,9 +5,9 @@
 * sender `Sender of the notification.`
 * timestamp `Timestamp of when the notification was triggered.`
 * recipients `Collection of notification recipients.`
-* title `Notification message.` (optional)
-* message `Notification message.`
+* title_key `Notification title key.`
+* message_key `Notification message key.`  (optional)
 * action_link `Correctly formatted URL to an internal or external action.`
 * status enum (READ, UNREAD) `Notification status.`
 
-
+See the Translations document for details on title_key and message_key fields

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -4,9 +4,9 @@
 * id (int) 11 auto_increment `ID of the notification.`
 * sender_key `Sender of the notification. As defined by the plugin or theme`
 * timestamp `Timestamp of when the notification was triggered.`
-* recipients `Collection of notification recipients.`
-* title_key `Notification title key.`
-* message_key `Notification message key.`  (optional)
+* recipient_key `Single notification recipient. As defined by the plugin or theme`
+* title_key `Notification title key. As defined by the plugin or theme`
+* message_key `Notification message key. As defined by the plugin or theme`  (optional)
 * action_link `Correctly formatted URL to an internal or external action.`
 * status enum (READ, UNREAD) `Notification status.`
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -5,7 +5,9 @@
 * sender `Sender of the notification.`
 * timestamp `Timestamp of when the notification was triggered.`
 * recipients `Collection of notification recipients.`
+* title `Notification message.` (optional)
 * message `Notification message.`
+* action_link `Correctly formatted URL to an internal or external action.`
 * status enum (READ, UNREAD) `Notification status.`
 
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,11 @@
+# Database Schema
+
+### wp_notifications table
+* id (int) 11 auto_increment `ID of the notification.`
+* sender `Sender of the notification.`
+* timestamp `Timestamp of when the notification was triggered.`
+* recipients `Collection of notification recipients.`
+* message `Notification message.`
+* status enum (READ, UNREAD) `Notification status.`
+
+

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -2,7 +2,7 @@
 
 ### wp_notifications table
 * id (int) 11 auto_increment `ID of the notification.`
-* sender `Sender of the notification.`
+* sender_key `Sender of the notification. As defined by the plugin or theme`
 * timestamp `Timestamp of when the notification was triggered.`
 * recipients `Collection of notification recipients.`
 * title_key `Notification title key.`

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,25 @@
+# Translations
+
+See also Database Schema
+
+To allow for internationalisation, the title and message text for a single notification is purposefully not stored in the database.
+
+Instead, a plugin or theme should store a key, which is linked to a translatable message in the plugin or theme's translation files.
+
+For example, given the following list of translatable strings in a plugin 
+
+```
+$notifications = array( 
+    'plugin_slug_new_podcast_title' => __('Some title', 'plugin-slug'), 
+    'plugin_slug_message' => __('Some message', 'plugin-slug'), 
+);
+```
+
+When adding a notification to the wp_notifications table, the values will be stored as follows
+
+```
+title_key = 'plugin_slug_new_podcast_title'
+message_key = 'plugin_slug_message'
+```
+
+The plugin will then be responsible for looking up these strings, and returning the translated version.


### PR DESCRIPTION
Documenting the Notification table schema, based on the properties of WPNotify_BaseNotification