### PR TITLE
Add support for wp-env

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,4 @@
+{
+	"core": "WordPress/WordPress",
+	"plugins": [ "." ]
+}

--- a/README.md
+++ b/README.md
@@ -2,10 +2,36 @@
 
 See [Trac ticket #43484](https://core.trac.wordpress.org/ticket/43484).
 
-## Development environment
+## Developing on a local environment
 
-Any WAMP/MAMP/LAMP local environment that works for WordPress development will be good enough.
+Any WAMP/MAMP/LAMP local environment with a WordPress installation will be suited for local development.
 
-However, it is possible to use the [wp-env tool](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/tutorials/devenv/readme.md#wordpress-development-site) developed by the Gutenberg team.
+### Running unit tests
 
-You will then need both Node.js and Docker installed on your computer. Read more about its usage in [WordPres/gutenberg/packages/env/README.md](https://github.com/WordPress/gutenberg/blob/master/packages/env/README.md).
+You need a local installation of [Composer](https://getcomposer.org/doc/00-intro.md).
+
+Then you need to install PHP dependencies.
+
+```bash
+composer install
+```
+
+And you can run the tests from the PHPUnit package:
+
+```bash
+vendor/bin/phpunit
+```
+
+## Developing with wp-env
+
+The [wp-env package](https://developer.wordpress.org/block-editor/packages/packages-env/) was developed with the Gutenberg project as a quick way to create a standard WordPress environment using Docker. It is also published as the `@wordpress/env` npm package.
+
+You can use it for contributing to the WP Notify project, but you need to install it on your computer first. read the [prerequisites](https://developer.wordpress.org/block-editor/packages/packages-env/#prerequisites) and the [install as a global package](https://developer.wordpress.org/block-editor/packages/packages-env/#installation-as-a-global-package) from its manual.
+
+### Running unit tests
+
+An npm script is provided in order to start the PHP unit tests:
+
+```bash
+npm run test-unit-php
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Notification Center for WordPress (Feature Project)
 
 See [Trac ticket #43484](https://core.trac.wordpress.org/ticket/43484).
+
+## Development environment
+
+Any WAMP/MAMP/LAMP local environment that works for WordPress development will be good enough.
+
+However, it is possible to use the [wp-env tool](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/tutorials/devenv/readme.md#wordpress-development-site) developed by the Gutenberg team.
+
+You will then need both Node.js and Docker installed on your computer. Read more about its usage in [WordPres/gutenberg/packages/env/README.md](https://github.com/WordPress/gutenberg/blob/master/packages/env/README.md).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@wordpress/wp-notify",
+  "version": "0.1.0",
+  "description": "A notification center for WordPress.",
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "scripts": {
+    "preinstall": "wp-env start",
+    "install": "wp-env run composer 'composer --ignore-platform-req=php install'",
+    "pretest-unit-php": "npm run install",
+    "test-unit-php": "wp-env run tests-cli '/var/www/html/wp-content/plugins/wp-notify/vendor/bin/phpunit --configuration=/var/www/html/wp-content/plugins/wp-notify/phpunit.xml.dist'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/WordPress/wp-notify.git"
+  },
+  "keywords": [
+    "WordPress",
+    "notifications",
+    "dashboard"
+  ],
+  "author": "The WordPress Contributors",
+  "license": "GPL-2.0-or-later",
+  "bugs": {
+    "url": "https://github.com/WordPress/wp-notify/issues"
+  },
+  "homepage": "https://github.com/WordPress/wp-notify#readme"
+}


### PR DESCRIPTION
## Changes

Adds a `.wp-env.json` configuration file to load WP Notify as a WordPress plugin when using [wp-env](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/tutorials/devenv/readme.md#wordpress-development-site) as the development environment.

## Details

I choose NOT to include the `@wordpress/env` package as a dependency of this project. Otherwise it would have been pulled for every contributor, whether they want to use `wp-env` as their development environment or not (which takes quite some time).

Fixes #14 