### PR TITLE
#40 Sender instance passed to the Factory

### DIFF
--- a/includes/Factory.php
+++ b/includes/Factory.php
@@ -2,7 +2,7 @@
 
 class WPNotify_Factory {
 
-	const MESSAGE    = 'message';
+	const MESSAGE = 'message';
 	const RECIPIENTS = 'recipients';
 
 	/**
@@ -19,28 +19,45 @@ class WPNotify_Factory {
 	 */
 	private $recipient_factory;
 
+	/**
+	 * Sender factory implementation to use
+	 *
+	 * @var WPNotify_SenderFactory
+	 */
+	private $sender_factory;
+
 	public function __construct(
 		WPNotify_MessageFactory $message_factory,
-		WPNotify_RecipientFactory $recipient_factory
+		WPNotify_RecipientFactory $recipient_factory,
+		WPNotify_SenderFactory $sender_factory
 	) {
-
 		$this->message_factory   = $message_factory;
 		$this->recipient_factory = $recipient_factory;
+		$this->sender_factory    = $sender_factory;
 	}
 
+	/**
+	 * Create a notification instance
+	 *
+	 * @param $args
+	 *
+	 * @return WPNotify_BaseNotification
+	 */
 	public function create( $args ) {
-		list( $message_args, $recipients_args ) = $this->validate( $args );
 
-		$message = $this->message_factory->create( $message_args );
+		[ $message_args, $recipients_args, $sender_args ] = $this->validate( $args );
 
+		$sender     = $this->sender_factory->create( $sender_args );
 		$recipients = new WPNotify_RecipientCollection();
+		$message    = $this->message_factory->create( $message_args );
+
 		foreach ( $recipients_args as $type => $value ) {
 			$recipients->add(
 				$this->recipient_factory->create( $value, $type )
 			);
 		}
 
-		return new WPNotify_BaseNotification( new BaseSender(), $message, $recipients );
+		return new WPNotify_BaseNotification( $sender, $recipients, $message );
 	}
 
 	private function validate( $args ) {
@@ -49,11 +66,12 @@ class WPNotify_Factory {
 			$args = json_decode( $args );
 		}
 
-		list( $message_args, $recipients_args ) = $args;
+		list( $message_args, $recipients_args, $sender_args ) = $args;
 
 		return array(
 			$this->get_message_args( $message_args ),
 			$this->get_recipients_args( $recipients_args ),
+			$this->get_sender_args( $sender_args ),
 		);
 	}
 
@@ -64,6 +82,11 @@ class WPNotify_Factory {
 
 	private function get_recipients_args( $args ) {
 		// TODO: Parse recipients args.
+		return $args;
+	}
+
+	public function get_sender_args( $args ) {
+		// TODO: Parse sender args.
 		return $args;
 	}
 }

--- a/includes/Factory.php
+++ b/includes/Factory.php
@@ -45,7 +45,7 @@ class WPNotify_Factory {
 	 */
 	public function create( $args ) {
 
-		[ $message_args, $recipients_args, $sender_args ] = $this->validate( $args );
+		list( $message_args, $recipients_args, $sender_args ) = $this->validate( $args );
 
 		$sender     = $this->sender_factory->create( $sender_args );
 		$recipients = new WPNotify_RecipientCollection();

--- a/includes/senders/BaseSender.php
+++ b/includes/senders/BaseSender.php
@@ -1,6 +1,6 @@
 <?php
 
-class WPNotify_BaseSender implements WPNotify_Sender {
+class WPNotify_BaseSender implements WPNotify_Sender, WPNotify_JsonUnserializable {
 
 	/**
 	 * @var string
@@ -23,5 +23,29 @@ class WPNotify_BaseSender implements WPNotify_Sender {
 		return array(
 			'name' => $this->name,
 		);
+	}
+
+	/**
+	 * Creates a new instance from JSON-encoded data.
+	 *
+	 * @param string $json JSON-encoded data to create the instance from.
+	 *
+	 * @return self
+	 */
+	public static function json_unserialize( $json ) {
+
+		$data = json_decode( $json, true );
+
+		$name = ! empty( $data['name'] ) ? $data['name'] : '';
+
+		return new self( $name );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_name() {
+
+		return $this->name;
 	}
 }

--- a/includes/senders/SenderFactory.php
+++ b/includes/senders/SenderFactory.php
@@ -9,5 +9,5 @@ interface WPNotify_SenderFactory {
 	 *
 	 * @return WPNotify_Sender
 	 */
-	public function create( string $name ): WPNotify_Sender;
+	public function create( $name );
 }

--- a/includes/senders/SenderFactory.php
+++ b/includes/senders/SenderFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+interface WPNotify_SenderFactory {
+
+	/**
+	 * Create a new instance of notification sender
+	 *
+	 * @param string $name
+	 *
+	 * @return WPNotify_Sender
+	 */
+	public function create( string $name ): WPNotify_Sender;
+}

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -4,4 +4,3 @@ require dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/wp-notify.php';
 
 require dirname( __FILE__ ) . '/stubs.php';
 require dirname( __FILE__ ) . '/TestCase.php';
-

--- a/tests/phpunit/tests/base-sender.php
+++ b/tests/phpunit/tests/base-sender.php
@@ -3,16 +3,30 @@
 class Test_WPNotify_BaseSender extends WPNotify_TestCase {
 
 	/**
-	 * @param string $senderName
-	 * @param string $expectedJson
+	 * @param string $sender_name
+	 * @param string $expected_json
 	 *
 	 * @dataProvider data_provider_senders
 	 */
-	public function test_it_can_be_json_encoded( $senderName, $expectedJson ) {
+	public function test_it_can_be_json_encoded( $sender_name, $expected_json ) {
 
-		$senderInstance = new WPNotify_BaseSender( $senderName );
+		$senderInstance = new WPNotify_BaseSender( $sender_name );
 		$encoded        = json_encode( $senderInstance );
-		$this->assertEquals( $expectedJson, $encoded );
+		$this->assertEquals( $expected_json, $encoded );
+	}
+
+	/**
+	 * @param string $sender_name
+	 * @param string $json
+	 *
+	 * @dataProvider data_provider_senders
+	 */
+	public function test_it_can_be_instantiated_from_json( $sender_name, $json ) {
+
+		$sender_instance = WPNotify_BaseSender::json_unserialize( $json );
+
+		$this->assertInstanceOf( 'WPNotify_BaseSender', $sender_instance );
+		$this->assertEquals( $sender_name, $sender_instance->get_name() );
 	}
 
 	public function data_provider_senders() {

--- a/tests/phpunit/tests/test-factory.php
+++ b/tests/phpunit/tests/test-factory.php
@@ -1,0 +1,38 @@
+<?php
+
+class Test_WPNotify_Factory extends WPNotify_TestCase {
+
+
+	public function test_create_with_vendor_sender() {
+
+		$vendor_sender = $this->createMock( 'WPNotify_Sender' );
+
+		$message_factory = $this->getMockBuilder( 'WPNotify_MessageFactory' )
+		                        ->setMethods( array( 'create', 'accepts' ) )
+		                        ->getMock();
+
+		$message_factory->method( 'create' )->willReturn( $this->createMock( 'WPNotify_Message' ) );
+		$message_factory->method( 'accepts' )->willReturn( true );
+
+		$sender_factory = $this->getMockBuilder( 'WPNotify_SenderFactory' )
+		                       ->setMethods( array( 'create' ) )
+		                       ->getMock();
+
+		$sender_factory->method( 'create' )->willReturn( $this->createMock( 'WPNotify_Sender' ) );
+
+		$factory = new WPNotify_Factory(
+			$message_factory,
+			$this->createMock( 'WPNotify_RecipientFactory' ),
+			$sender_factory
+		);
+
+		$args = array(
+			array(),
+			array(),
+			array(),
+		);
+
+		$notification = $factory->create( $args );
+		$this->assertEquals( $vendor_sender, $notification->get_sender() );
+	}
+}


### PR DESCRIPTION
I've chosen to implement a Sender Factory and send it along to Factory's constructor in order to have code consistency and have it processed/validated by Factory's logic.