### PR TITLE
Add PHP linting and unit tests to a GitHub workflow

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -37,3 +37,31 @@ jobs:
 
     - name: Run PHP Unit tests
       run: composer run test
+
+  lint:
+    name: WordPress Coding Standards
+    runs-on: ubuntu-18.04
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles( './composer.lock' ) }}
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Sniff Code
+        continue-on-error: true
+        run: composer run lint

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -1,21 +1,27 @@
-name: PHP Composer
+name: Run Unit Tests on PR
 
 on:
-  push:
-    branches: [ develop, trunk ]
   pull_request:
     branches: [ develop, trunk ]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.2', '7.3', '7.4' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate --strict --no-check-publish
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        tools: composer
 
     - name: Cache Composer packages
       id: composer-cache
@@ -28,9 +34,6 @@ jobs:
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
-
-    - name: Check Coding Standards
-      run: composer run lint
 
     - name: Run PHP Unit tests
       run: composer run test

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -63,5 +63,4 @@ jobs:
         run: composer install
 
       - name: Sniff Code
-        continue-on-error: true
         run: composer run lint

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -1,0 +1,36 @@
+name: PHP Composer
+
+on:
+  push:
+    branches: [ develop, trunk ]
+  pull_request:
+    branches: [ develop, trunk ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict --no-check-publish
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Check Coding Standards
+      run: composer run lint
+
+    - name: Run PHP Unit tests
+      run: composer run test

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "lint": "vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source"
+        "lint": "vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
+	"test": "vendor/bin/phpunit"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -79,36 +79,31 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -122,7 +117,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -131,20 +126,38 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "johnkary/phpunit-speedtrap",
-            "version": "v3.2.0",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnkary/phpunit-speedtrap.git",
-                "reference": "8c0e149b80c6e86c33315f05699512678655c158"
+                "reference": "9ba81d42676da31366c85d3ff8c10a8352d02030"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/8c0e149b80c6e86c33315f05699512678655c158",
-                "reference": "8c0e149b80c6e86c33315f05699512678655c158",
+                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/9ba81d42676da31366c85d3ff8c10a8352d02030",
+                "reference": "9ba81d42676da31366c85d3ff8c10a8352d02030",
                 "shasum": ""
             },
             "require": {
@@ -154,7 +167,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -179,20 +192,24 @@
                 "profile",
                 "slow"
             ],
-            "time": "2020-02-12T16:19:51+00:00"
+            "support": {
+                "issues": "https://github.com/johnkary/phpunit-speedtrap/issues",
+                "source": "https://github.com/johnkary/phpunit-speedtrap/tree/v3.3.0"
+            },
+            "time": "2020-12-18T16:20:16+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
@@ -227,7 +244,17 @@
                 "object",
                 "object graph"
             ],
-            "time": "2020-06-29T13:22:24+00:00"
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -282,6 +309,10 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
             "time": "2018-07-08T19:23:20+00:00"
         },
         {
@@ -329,6 +360,10 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/master"
+            },
             "time": "2018-07-08T19:19:57+00:00"
         },
         {
@@ -378,6 +413,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
             "time": "2020-06-27T09:03:43+00:00"
         },
         {
@@ -430,6 +469,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
             "time": "2020-09-03T19:13:55+00:00"
         },
         {
@@ -475,32 +518,36 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
             "time": "2020-09-17T18:55:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.11.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b20034be5efcdab4fb60ca3a29cba2949aead160",
-                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2",
-                "phpdocumentor/reflection-docblock": "^5.0",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -538,7 +585,11 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-07-08T12:44:21+00:00"
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
+            },
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -601,27 +652,31 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/master"
+            },
             "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -651,7 +706,17 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-09-13T20:33:42+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:25:21+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -692,27 +757,31 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
             "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -741,25 +810,35 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-06-07T04:22:29+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.0"
@@ -790,8 +869,18 @@
             "keywords": [
                 "tokenizer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "abandoned": true,
-            "time": "2019-09-17T06:23:10+00:00"
+            "time": "2020-11-30T08:38:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -875,27 +964,31 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/7.5.20"
+            },
             "time": "2020-01-08T08:45:45+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -920,29 +1013,39 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
+                "php": ">=7.1",
                 "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -961,6 +1064,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -971,10 +1078,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -984,24 +1087,34 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-07-12T15:12:46+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:04:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5 || ^8.0",
@@ -1024,12 +1137,12 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
@@ -1040,24 +1153,34 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2019-02-04T06:01:07+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.3",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5"
@@ -1093,24 +1216,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-11-20T08:46:58+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:53:42+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": ">=7.0",
                 "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
@@ -1160,7 +1293,17 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-09-14T09:02:43+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:47:53+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1211,24 +1354,28 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+            },
             "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": ">=7.0",
                 "sebastian/object-reflector": "^1.1.1",
                 "sebastian/recursion-context": "^3.0"
             },
@@ -1258,24 +1405,34 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:40:27+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0"
@@ -1303,24 +1460,34 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:37:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0"
@@ -1342,12 +1509,12 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -1356,24 +1523,34 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:34:24+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
@@ -1398,7 +1575,17 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04T04:07:39+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1441,20 +1628,24 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -1497,24 +1688,24 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.1",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -1522,7 +1713,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1559,7 +1750,24 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1599,34 +1807,49 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -1648,7 +1871,11 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-07-08T17:02:28+00:00"
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,15 +10,4 @@
             <directory suffix=".php" phpVersion="*">tests/phpunit/tests</directory>
         </testsuite>
     </testsuites>
-	<listeners>
-		<listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener">
-			<arguments>
-				<array>
-					<element key="slowThreshold">
-						<integer>150</integer>
-					</element>
-				</array>
-			</arguments>
-		</listener>
-	</listeners>
 </phpunit>

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -1,7 +1,0 @@
-<?php
-
-use PHPUnit\Framework\TestCase;
-
-class WPNotify_TestCase extends TestCase {
-
-}

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -1,6 +1,36 @@
 <?php
 
-require dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/wp-notify.php';
+require __DIR__ . '/../../../vendor/autoload.php';
 
-require dirname( __FILE__ ) . '/stubs.php';
-require dirname( __FILE__ ) . '/TestCase.php';
+$tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $tests_dir ) {
+	$tests_dir = getenv( 'WP_PHPUNIT__DIR' );
+}
+
+if ( ! $tests_dir ) {
+	$tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once $tests_dir . '/includes/functions.php';
+
+function manually_load_plugin() {
+	require __DIR__ . '/../../../wp-notify.php';
+}
+tests_add_filter( 'plugins_loaded', 'manually_load_plugin' );
+
+function handle_wp_setup_failure( $message ) {
+	if ( is_wp_error( $message ) ) {
+		$message = $message->get_error_message();
+	}
+
+	throw new Exception( 'WordPress died: ' . $message );
+}
+tests_add_filter( 'wp_die_handler', 'handle_wp_setup_failure' );
+
+require $tests_dir . '/includes/bootstrap.php';
+
+remove_filter( 'wp_die_handler', 'handle_wp_setup_failure' );
+
+require dirname( __FILE__ ) . '/class-dummy-message.php';
+require dirname( __FILE__ ) . '/class-wp-notify-test-case.php';

--- a/tests/phpunit/includes/class-dummy-message.php
+++ b/tests/phpunit/includes/class-dummy-message.php
@@ -1,18 +1,6 @@
 <?php
 
-function __( $text, $domain ) {
-	return $text;
-}
-
-function _doing_it_wrong( $function, $message ) {
-	throw new Exception( "{$function} - {$message}" );
-}
-
-function apply_filters( $filter, $value ) {
-	return $value;
-}
-
-class DummyMessage implements WP_Notify_Message {
+class Dummy_Message implements WP_Notify_Message {
 
 	public function serialize() {
 		return ''; }

--- a/tests/phpunit/includes/class-wp-notify-test-case.php
+++ b/tests/phpunit/includes/class-wp-notify-test-case.php
@@ -1,0 +1,7 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class WP_Notify_TestCase extends TestCase {
+
+}

--- a/tests/phpunit/tests/test-wp-notify-base-image.php
+++ b/tests/phpunit/tests/test-wp-notify-base-image.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_BaseImage extends WPNotify_TestCase {
+class Test_WP_Notify_BaseImage extends WP_Notify_TestCase {
 
 	/**
 	 * @param array  $image_data

--- a/tests/phpunit/tests/test-wp-notify-base-message.php
+++ b/tests/phpunit/tests/test-wp-notify-base-message.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Base_Message extends WPNotify_TestCase {
+class Test_WP_Notify_Base_Message extends WP_Notify_TestCase {
 
 	const SERIALIZED = 'C:20:"WPNotify_BaseMessage":14:{s:7:"Message";}';
 

--- a/tests/phpunit/tests/test-wp-notify-base-notification.php
+++ b/tests/phpunit/tests/test-wp-notify-base-notification.php
@@ -1,35 +1,35 @@
 <?php
 
-class Test_WP_Notify_Base_Notification extends WPNotify_TestCase {
+class Test_WP_Notify_Base_Notification extends WP_Notify_TestCase {
 
 	const JSON_SERIALIZED = '{"WP_Notify_Recipient_Collection":[],"WP_Notify_Base_Message":"Message","WP_Notify_Base_Sender":{"name":"Name 1"}}';
 
 	public function test_it_can_be_instantiated() {
-		$sender_mock     = $this->createMock('WP_Notify_Base_Sender');
-		$recipients_mock = $this->createMock('WP_Notify_Recipient_Collection');
+		$sender_mock     = $this->createMock( 'WP_Notify_Base_Sender' );
+		$recipients_mock = $this->createMock( 'WP_Notify_Recipient_Collection' );
 		$testee          = new WP_Notify_Base_Notification(
 			$sender_mock,
 			$recipients_mock,
-			new DummyMessage()
+			new Dummy_Message()
 		);
 		$this->assertInstanceOf( 'WP_Notify_Base_Notification', $testee );
 	}
 
 	public function test_it_implements_the_interface() {
-		$sender_mock     = $this->createMock('WP_Notify_Base_Sender');
-		$recipients_mock = $this->createMock('WP_Notify_Recipient_Collection');
+		$sender_mock     = $this->createMock( 'WP_Notify_Base_Sender' );
+		$recipients_mock = $this->createMock( 'WP_Notify_Recipient_Collection' );
 		$testee          = new WP_Notify_Base_Notification(
 			$sender_mock,
 			$recipients_mock,
-			new DummyMessage()
+			new Dummy_Message()
 		);
 		$this->assertInstanceOf( 'WP_Notify_Notification', $testee );
 	}
 
 	public function test_it_can_return_its_content() {
-		$sender_mock     = $this->createMock('WP_Notify_Base_Sender');
-		$recipients_mock = $this->createMock('WP_Notify_Recipient_Collection');
-		$dummy_message   = new DummyMessage();
+		$sender_mock     = $this->createMock( 'WP_Notify_Base_Sender' );
+		$recipients_mock = $this->createMock( 'WP_Notify_Recipient_Collection' );
+		$dummy_message   = new Dummy_Message();
 		$testee          = new WP_Notify_Base_Notification(
 			$sender_mock,
 			$recipients_mock,

--- a/tests/phpunit/tests/test-wp-notify-base-sender.php
+++ b/tests/phpunit/tests/test-wp-notify-base-sender.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Base_Sender extends WPNotify_TestCase {
+class Test_WP_Notify_Base_Sender extends WP_Notify_TestCase {
 
 	/**
 	 * @param array  $sender_params
@@ -10,7 +10,7 @@ class Test_WP_Notify_Base_Sender extends WPNotify_TestCase {
 	 */
 	public function test_it_can_be_json_encoded( $sender_params, $expected_json ) {
 
-		$sender_reflection = new ReflectionClass('WP_Notify_Base_Sender');
+		$sender_reflection = new ReflectionClass( 'WP_Notify_Base_Sender' );
 		$sender            = $sender_reflection->newInstanceArgs( array_values( $sender_params ) );
 
 		$sender_encoded = json_encode( $sender );
@@ -28,7 +28,7 @@ class Test_WP_Notify_Base_Sender extends WPNotify_TestCase {
 
 		$testee = WP_Notify_Base_Sender::json_unserialize( $json );
 
-		$sender_reflection = new ReflectionClass('WP_Notify_Base_Sender');
+		$sender_reflection = new ReflectionClass( 'WP_Notify_Base_Sender' );
 		/** @var WP_Notify_Base_Sender $sender */
 		$sender = $sender_reflection->newInstanceArgs( array_values( (array) $sender_params ) );
 
@@ -60,7 +60,7 @@ class Test_WP_Notify_Base_Sender extends WPNotify_TestCase {
 
 			'sender with image'    => array(
 				array(
-					'name'               => 'Name 2',
+					'name'                 => 'Name 2',
 					'WP_Notify_Base_Image' => new WP_Notify_Base_Image( 'img-source', 'img-alt' ),
 				),
 				'{"name":"Name 2","WP_Notify_Base_Image":{"source":"img-source","alt":"img-alt"}}',

--- a/tests/phpunit/tests/test-wp-notify-factory.php
+++ b/tests/phpunit/tests/test-wp-notify-factory.php
@@ -1,28 +1,28 @@
 <?php
 
-class Test_WP_Notify_Factory extends WPNotify_TestCase {
+class Test_WP_Notify_Factory extends WP_Notify_TestCase {
 
 
 	public function test_create_with_vendor_sender() {
 
-		$vendor_sender = $this->createMock('WP_Notify_Sender');
+		$vendor_sender = $this->createMock( 'WP_Notify_Sender' );
 
-		$message_factory = $this->getMockBuilder('WP_Notify_Message_Factory')
+		$message_factory = $this->getMockBuilder( 'WP_Notify_Message_Factory' )
 								->setMethods( array( 'create', 'accepts' ) )
 								->getMock();
 
-		$message_factory->method( 'create' )->willReturn( $this->createMock('WP_Notify_Message') );
+		$message_factory->method( 'create' )->willReturn( $this->createMock( 'WP_Notify_Message' ) );
 		$message_factory->method( 'accepts' )->willReturn( true );
 
-		$sender_factory = $this->getMockBuilder('WP_Notify_Sender_Factory')
-							   ->setMethods( array( 'create' ) )
-							   ->getMock();
+		$sender_factory = $this->getMockBuilder( 'WP_Notify_Sender_Factory' )
+			->setMethods( array( 'create' ) )
+			->getMock();
 
-		$sender_factory->method( 'create' )->willReturn( $this->createMock('WP_Notify_Sender') );
+		$sender_factory->method( 'create' )->willReturn( $this->createMock( 'WP_Notify_Sender' ) );
 
 		$factory = new WP_Notify_Factory(
 			$message_factory,
-			$this->createMock('WP_Notify_Recipient_Factory'),
+			$this->createMock( 'WP_Notify_Recipient_Factory' ),
 			$sender_factory
 		);
 

--- a/tests/phpunit/tests/test-wp-notify-notification-repository.php
+++ b/tests/phpunit/tests/test-wp-notify-notification-repository.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Wpdb_Notification_Repository extends WPNotify_TestCase {
+class Test_WP_Notify_Wpdb_Notification_Repository extends WP_Notify_TestCase {
 
 	/** @dataProvider data_provider_it_returns_false_on_invalid_ids */
 	public function test_it_returns_false_on_invalid_ids( $id ) {

--- a/tests/phpunit/tests/test-wp-notify-recipient-collection.php
+++ b/tests/phpunit/tests/test-wp-notify-recipient-collection.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Recipient_Collection extends WPNotify_TestCase {
+class Test_WP_Notify_Recipient_Collection extends WP_Notify_TestCase {
 
 	const SERIALIZED = 'C:28:"WPNotify_RecipientCollection":6:{a:0:{}}';
 
@@ -25,15 +25,15 @@ class Test_WP_Notify_Recipient_Collection extends WPNotify_TestCase {
 	}
 
 	public function test_it_can_accept_a_singular_recipient() {
-		$mock_recipient = $this->createMock('WP_Notify_Recipient');
+		$mock_recipient = $this->createMock( 'WP_Notify_Recipient' );
 		$testee         = new WP_Notify_Recipient_Collection( $mock_recipient );
 		$this->assertCount( 1, $testee );
 	}
 
 	public function test_it_can_accept_an_array_of_recipients() {
-		$mock_recipient_1 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_2 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_3 = $this->createMock('WP_Notify_Recipient');
+		$mock_recipient_1 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_2 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_3 = $this->createMock( 'WP_Notify_Recipient' );
 		$testee           = new WP_Notify_Recipient_Collection(
 			array(
 				$mock_recipient_1,
@@ -45,9 +45,9 @@ class Test_WP_Notify_Recipient_Collection extends WPNotify_TestCase {
 	}
 
 	public function test_recipients_can_be_added() {
-		$mock_recipient_1 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_2 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_3 = $this->createMock('WP_Notify_Recipient');
+		$mock_recipient_1 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_2 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_3 = $this->createMock( 'WP_Notify_Recipient' );
 		$testee           = new WP_Notify_Recipient_Collection( $mock_recipient_1 );
 		$this->assertCount( 1, $testee );
 		$testee->add( $mock_recipient_2 );
@@ -58,13 +58,13 @@ class Test_WP_Notify_Recipient_Collection extends WPNotify_TestCase {
 
 	/** @dataProvider data_provider_it_throws_on_invalid_type */
 	public function test_it_throws_on_invalid_type( $invalid_recipient ) {
-		$this->expectException('WP_Notify_Runtime_Exception');
+		$this->expectException( 'WP_Notify_Runtime_Exception' );
 		new WP_Notify_Recipient_Collection( $invalid_recipient );
 	}
 
 	public function data_provider_it_throws_on_invalid_type() {
-		$mock_recipient_1 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_2 = $this->createMock('WP_Notify_Recipient');
+		$mock_recipient_1 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_2 = $this->createMock( 'WP_Notify_Recipient' );
 
 		return array(
 			array( null ),

--- a/tests/phpunit/tests/test-wp-notify-role-recipient.php
+++ b/tests/phpunit/tests/test-wp-notify-role-recipient.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Role_Recipient extends WPNotify_TestCase {
+class Test_WP_Notify_Role_Recipient extends WP_Notify_TestCase {
 
 	public function test_it_can_be_instantiated() {
 		$testee = new WP_Notify_Role_Recipient( 1 );

--- a/tests/phpunit/tests/test-wp-notify-user-recipient.php
+++ b/tests/phpunit/tests/test-wp-notify-user-recipient.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_User_Recipient extends WPNotify_TestCase {
+class Test_WP_Notify_User_Recipient extends WP_Notify_TestCase {
 
 	public function test_it_can_be_instantiated() {
 		$testee = new WP_Notify_User_Recipient( 1 );
@@ -19,7 +19,7 @@ class Test_WP_Notify_User_Recipient extends WPNotify_TestCase {
 
 	/** @dataProvider data_provider_it_throws_on_invalid_type */
 	public function test_it_throws_on_invalid_type( $invalid_user_id ) {
-		$this->expectException('WP_Notify_Invalid_Recipient');
+		$this->expectException( 'WP_Notify_Invalid_Recipient' );
 		new WP_Notify_User_Recipient( $invalid_user_id );
 	}
 


### PR DESCRIPTION
## Goal

This PR aims to automatically check the WordPress Code Standards and run our PHP unit tests each time a pull request is made on our `develop` and `trunk` branches.

See #10 

- Inspired by [woccommerce/woocommerce](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/pr-unit-tests.yml)
- Uses [shivammathur/setup-php](https://github.com/shivammathur/setup-php)
- Runs on Ubuntu 18.04 to benefit from pre-installed PHP versions, see: https://github.com/shivammathur/setup-php#tada-php-support
- #53 Needs to be merged first for our code sniffes to pass

## Running locally

The GitHub actions can be run locally using [nektos/act](https://github.com/nektos/act) and [shivammathur/node-docker](https://github.com/shivammathur/node-docker). See explanation: https://github.com/shivammathur/setup-php#local-testing-setup

Run the command

```bash
act -P ubuntu-18.04=shivammathur/node:bionic pull_request
```

## WIP

- [x] ~~Can't run the action locally using [nektos/Act](https://github.com/nektos/act): The composer package appears missing (medium install)~~ 
- [x] ~~The action runs on the server but breaks because our set of dependencies are not compatible with PHP 8~~
- [x] Could be useful to set a matrix of PHP versions to run the unit tests with. **For the moment only runs on PHP 7.2, 7.3 and 7.4.**
- [x] The linting can be separated from the PHP versions matrix.
- [ ] Won't be enough to run integration tests, because it needs a setup connecting a MySQL database and a WordPress install. See how [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop/blob/master/.github/workflows/phpunit-tests.yml) and [WordPress/gutenberg](https://github.com/WordPress/gutenberg/blob/bee52e68292357011a799f067ad47aa1c1d710e1/.github/workflows/unit-test.yml#L52) manage it.
- [x] Coding standards should show as failed... when failing