### PR TITLE
Run Unit Tests and Coding Standards on Pull Request

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -62,37 +62,12 @@ jobs:
     name: Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-          tools: composer
-          extensions: mysql
-          coverage: none
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Composer packages
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
-
-      - name: PHPCS check
-        uses: chekalsky/phpcs-action@v1
+      - uses: actions/checkout@v2
+      - name: WPCS check
+        uses: 10up/wpcs-action@v1.3.1
         with:
           enable_warnings: true
-          phpcs_bin_path: './vendor/bin/phpcs'
+          use_local_config: true
 
 
 

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -59,24 +59,25 @@ jobs:
       run: composer run test
 
   lint:
-    name: Check WordPress Coding Standards
+    name: Check Coding Standards
     runs-on: ubuntu-latest
-    
-    steps: 
+    steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
-        with: 
-          php-version: '7.4'
+        with:
+          php-version: 7.4
           tools: composer
+          extensions: mysql
+          coverage: none
 
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - name: Cache composer packages
+      - name: Cache Composer packages
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
@@ -85,8 +86,14 @@ jobs:
             ${{ runner.os }}-php-
 
       - name: Install dependencies
-        run: composer install
+        run: composer install --prefer-dist --no-progress
 
-      - name: Check coding standards
-        run: ./vendor/bin/phpcs --report=summary .
-    
+      - name: PHPCS check
+        uses: chekalsky/phpcs-action@v1
+        with:
+          enable_warnings: true
+          phpcs_bin_path: './vendor/bin/phpcs'
+
+
+
+

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -1,0 +1,92 @@
+name: PHP Continuous Integration
+
+on:
+  pull_request:
+    branches: [ develop, trunk ]
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }} WP ${{ matrix.wp }}
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      WP_TESTS_DIR: /tmp/wordpress-tests-lib
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.2', '7.3', '7.4' ]
+        wp: [ 'latest' ]
+    services:
+      database:
+        image: mysql:5.6
+        env:
+          MYSQL_ROOT_PASSWORD: wordpress
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        tools: composer
+        extensions: mysql
+        coverage: none
+
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - name: Cache Composer packages
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Install WordPress and initialize database
+      run: ./tests/bin/install-wp-tests.sh wp_notify_tests root wordpress 127.0.0.1 latest
+
+    - name: Run PHP Unit tests
+      run: composer run test
+
+  lint:
+    name: Check WordPress Coding Standards
+    runs-on: ubuntu-latest
+    
+    steps: 
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with: 
+          php-version: '7.4'
+          tools: composer
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Check coding standards
+        run: ./vendor/bin/phpcs --report=summary .
+    

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "lint": "vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source"
+        "lint": "vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
+	"test": "vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "lint": "vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
-	"test": "vendor/bin/phpunit"
+        "lint": "vendor/bin/phpcs",
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1640,16 +1640,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -1661,7 +1661,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1699,7 +1699,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -1715,7 +1715,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/includes/restapi/class-wp-notify-notification-controller.php
+++ b/includes/restapi/class-wp-notify-notification-controller.php
@@ -1,0 +1,2 @@
+<?php
+// TODO: Implement class

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
+		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
+		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -1,7 +1,0 @@
-<?php
-
-use PHPUnit\Framework\TestCase;
-
-class WPNotify_TestCase extends WP_UnitTestCase {
-
-}

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -5,26 +5,26 @@ require __DIR__ . '/../../../vendor/autoload.php';
 $tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $tests_dir ) {
-    $tests_dir = getenv( 'WP_PHPUNIT__DIR' );
+	$tests_dir = getenv( 'WP_PHPUNIT__DIR' );
 }
 
 if ( ! $tests_dir ) {
-    $tests_dir = '/tmp/wordpress-tests-lib';
+	$tests_dir = '/tmp/wordpress-tests-lib';
 }
 
 require_once $tests_dir . '/includes/functions.php';
 
 function manually_load_plugin() {
-    require __DIR__ . '/../../../wp-notify.php';
+	require __DIR__ . '/../../../wp-notify.php';
 }
 tests_add_filter( 'plugins_loaded', 'manually_load_plugin' );
 
 function handle_wp_setup_failure( $message ) {
-    if ( is_wp_error( $message ) ) {
-        $message = $message->get_error_message();
-    }
+	if ( is_wp_error( $message ) ) {
+		$message = $message->get_error_message();
+	}
 
-    throw new Exception( 'WordPress died: ' . $message );
+	throw new Exception( 'WordPress died: ' . $message );
 }
 tests_add_filter( 'wp_die_handler', 'handle_wp_setup_failure' );
 
@@ -32,5 +32,5 @@ require $tests_dir . '/includes/bootstrap.php';
 
 remove_filter( 'wp_die_handler', 'handle_wp_setup_failure' );
 
-require dirname( __FILE__ ) . '/stubs.php';
-require dirname( __FILE__ ) . '/TestCase.php';
+require dirname( __FILE__ ) . '/class-dummy-message.php';
+require dirname( __FILE__ ) . '/class-wp-notify-test-case.php';

--- a/tests/phpunit/includes/class-dummy-message.php
+++ b/tests/phpunit/includes/class-dummy-message.php
@@ -1,6 +1,6 @@
 <?php
 
-class DummyMessage implements WP_Notify_Message {
+class Dummy_Message implements WP_Notify_Message {
 
 	public function serialize() {
 		return ''; }

--- a/tests/phpunit/includes/class-wp-notify-test-case.php
+++ b/tests/phpunit/includes/class-wp-notify-test-case.php
@@ -1,0 +1,7 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class WP_Notify_TestCase extends TestCase {
+
+}

--- a/tests/phpunit/tests/test-wp-notify-base-image.php
+++ b/tests/phpunit/tests/test-wp-notify-base-image.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_BaseImage extends WPNotify_TestCase {
+class Test_WP_Notify_BaseImage extends WP_Notify_TestCase {
 
 	/**
 	 * @param array  $image_data

--- a/tests/phpunit/tests/test-wp-notify-base-message.php
+++ b/tests/phpunit/tests/test-wp-notify-base-message.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Base_Message extends WPNotify_TestCase {
+class Test_WP_Notify_Base_Message extends WP_Notify_TestCase {
 
 	const SERIALIZED = 'C:20:"WPNotify_BaseMessage":14:{s:7:"Message";}';
 

--- a/tests/phpunit/tests/test-wp-notify-base-notification.php
+++ b/tests/phpunit/tests/test-wp-notify-base-notification.php
@@ -1,35 +1,35 @@
 <?php
 
-class Test_WP_Notify_Base_Notification extends WPNotify_TestCase {
+class Test_WP_Notify_Base_Notification extends WP_Notify_TestCase {
 
 	const JSON_SERIALIZED = '{"WP_Notify_Recipient_Collection":[],"WP_Notify_Base_Message":"Message","WP_Notify_Base_Sender":{"name":"Name 1"}}';
 
 	public function test_it_can_be_instantiated() {
-		$sender_mock     = $this->createMock('WP_Notify_Base_Sender');
-		$recipients_mock = $this->createMock('WP_Notify_Recipient_Collection');
+		$sender_mock     = $this->createMock( 'WP_Notify_Base_Sender' );
+		$recipients_mock = $this->createMock( 'WP_Notify_Recipient_Collection' );
 		$testee          = new WP_Notify_Base_Notification(
 			$sender_mock,
 			$recipients_mock,
-			new DummyMessage()
+			new Dummy_Message()
 		);
 		$this->assertInstanceOf( 'WP_Notify_Base_Notification', $testee );
 	}
 
 	public function test_it_implements_the_interface() {
-		$sender_mock     = $this->createMock('WP_Notify_Base_Sender');
-		$recipients_mock = $this->createMock('WP_Notify_Recipient_Collection');
+		$sender_mock     = $this->createMock( 'WP_Notify_Base_Sender' );
+		$recipients_mock = $this->createMock( 'WP_Notify_Recipient_Collection' );
 		$testee          = new WP_Notify_Base_Notification(
 			$sender_mock,
 			$recipients_mock,
-			new DummyMessage()
+			new Dummy_Message()
 		);
 		$this->assertInstanceOf( 'WP_Notify_Notification', $testee );
 	}
 
 	public function test_it_can_return_its_content() {
-		$sender_mock     = $this->createMock('WP_Notify_Base_Sender');
-		$recipients_mock = $this->createMock('WP_Notify_Recipient_Collection');
-		$dummy_message   = new DummyMessage();
+		$sender_mock     = $this->createMock( 'WP_Notify_Base_Sender' );
+		$recipients_mock = $this->createMock( 'WP_Notify_Recipient_Collection' );
+		$dummy_message   = new Dummy_Message();
 		$testee          = new WP_Notify_Base_Notification(
 			$sender_mock,
 			$recipients_mock,

--- a/tests/phpunit/tests/test-wp-notify-base-sender.php
+++ b/tests/phpunit/tests/test-wp-notify-base-sender.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Base_Sender extends WPNotify_TestCase {
+class Test_WP_Notify_Base_Sender extends WP_Notify_TestCase {
 
 	/**
 	 * @param array  $sender_params
@@ -10,7 +10,7 @@ class Test_WP_Notify_Base_Sender extends WPNotify_TestCase {
 	 */
 	public function test_it_can_be_json_encoded( $sender_params, $expected_json ) {
 
-		$sender_reflection = new ReflectionClass('WP_Notify_Base_Sender');
+		$sender_reflection = new ReflectionClass( 'WP_Notify_Base_Sender' );
 		$sender            = $sender_reflection->newInstanceArgs( array_values( $sender_params ) );
 
 		$sender_encoded = json_encode( $sender );
@@ -28,7 +28,7 @@ class Test_WP_Notify_Base_Sender extends WPNotify_TestCase {
 
 		$testee = WP_Notify_Base_Sender::json_unserialize( $json );
 
-		$sender_reflection = new ReflectionClass('WP_Notify_Base_Sender');
+		$sender_reflection = new ReflectionClass( 'WP_Notify_Base_Sender' );
 		/** @var WP_Notify_Base_Sender $sender */
 		$sender = $sender_reflection->newInstanceArgs( array_values( (array) $sender_params ) );
 
@@ -60,7 +60,7 @@ class Test_WP_Notify_Base_Sender extends WPNotify_TestCase {
 
 			'sender with image'    => array(
 				array(
-					'name'               => 'Name 2',
+					'name'                 => 'Name 2',
 					'WP_Notify_Base_Image' => new WP_Notify_Base_Image( 'img-source', 'img-alt' ),
 				),
 				'{"name":"Name 2","WP_Notify_Base_Image":{"source":"img-source","alt":"img-alt"}}',

--- a/tests/phpunit/tests/test-wp-notify-factory.php
+++ b/tests/phpunit/tests/test-wp-notify-factory.php
@@ -1,28 +1,28 @@
 <?php
 
-class Test_WP_Notify_Factory extends WPNotify_TestCase {
+class Test_WP_Notify_Factory extends WP_Notify_TestCase {
 
 
 	public function test_create_with_vendor_sender() {
 
-		$vendor_sender = $this->createMock('WP_Notify_Sender');
+		$vendor_sender = $this->createMock( 'WP_Notify_Sender' );
 
-		$message_factory = $this->getMockBuilder('WP_Notify_Message_Factory')
+		$message_factory = $this->getMockBuilder( 'WP_Notify_Message_Factory' )
 								->setMethods( array( 'create', 'accepts' ) )
 								->getMock();
 
-		$message_factory->method( 'create' )->willReturn( $this->createMock('WP_Notify_Message') );
+		$message_factory->method( 'create' )->willReturn( $this->createMock( 'WP_Notify_Message' ) );
 		$message_factory->method( 'accepts' )->willReturn( true );
 
-		$sender_factory = $this->getMockBuilder('WP_Notify_Sender_Factory')
-							   ->setMethods( array( 'create' ) )
-							   ->getMock();
+		$sender_factory = $this->getMockBuilder( 'WP_Notify_Sender_Factory' )
+			->setMethods( array( 'create' ) )
+			->getMock();
 
-		$sender_factory->method( 'create' )->willReturn( $this->createMock('WP_Notify_Sender') );
+		$sender_factory->method( 'create' )->willReturn( $this->createMock( 'WP_Notify_Sender' ) );
 
 		$factory = new WP_Notify_Factory(
 			$message_factory,
-			$this->createMock('WP_Notify_Recipient_Factory'),
+			$this->createMock( 'WP_Notify_Recipient_Factory' ),
 			$sender_factory
 		);
 

--- a/tests/phpunit/tests/test-wp-notify-notification-repository.php
+++ b/tests/phpunit/tests/test-wp-notify-notification-repository.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Wpdb_Notification_Repository extends WPNotify_TestCase {
+class Test_WP_Notify_Wpdb_Notification_Repository extends WP_Notify_TestCase {
 
 	/** @dataProvider data_provider_it_returns_false_on_invalid_ids */
 	public function test_it_returns_false_on_invalid_ids( $id ) {

--- a/tests/phpunit/tests/test-wp-notify-recipient-collection.php
+++ b/tests/phpunit/tests/test-wp-notify-recipient-collection.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Recipient_Collection extends WPNotify_TestCase {
+class Test_WP_Notify_Recipient_Collection extends WP_Notify_TestCase {
 
 	const SERIALIZED = 'C:28:"WPNotify_RecipientCollection":6:{a:0:{}}';
 
@@ -25,15 +25,15 @@ class Test_WP_Notify_Recipient_Collection extends WPNotify_TestCase {
 	}
 
 	public function test_it_can_accept_a_singular_recipient() {
-		$mock_recipient = $this->createMock('WP_Notify_Recipient');
+		$mock_recipient = $this->createMock( 'WP_Notify_Recipient' );
 		$testee         = new WP_Notify_Recipient_Collection( $mock_recipient );
 		$this->assertCount( 1, $testee );
 	}
 
 	public function test_it_can_accept_an_array_of_recipients() {
-		$mock_recipient_1 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_2 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_3 = $this->createMock('WP_Notify_Recipient');
+		$mock_recipient_1 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_2 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_3 = $this->createMock( 'WP_Notify_Recipient' );
 		$testee           = new WP_Notify_Recipient_Collection(
 			array(
 				$mock_recipient_1,
@@ -45,9 +45,9 @@ class Test_WP_Notify_Recipient_Collection extends WPNotify_TestCase {
 	}
 
 	public function test_recipients_can_be_added() {
-		$mock_recipient_1 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_2 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_3 = $this->createMock('WP_Notify_Recipient');
+		$mock_recipient_1 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_2 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_3 = $this->createMock( 'WP_Notify_Recipient' );
 		$testee           = new WP_Notify_Recipient_Collection( $mock_recipient_1 );
 		$this->assertCount( 1, $testee );
 		$testee->add( $mock_recipient_2 );
@@ -58,13 +58,13 @@ class Test_WP_Notify_Recipient_Collection extends WPNotify_TestCase {
 
 	/** @dataProvider data_provider_it_throws_on_invalid_type */
 	public function test_it_throws_on_invalid_type( $invalid_recipient ) {
-		$this->expectException('WP_Notify_Runtime_Exception');
+		$this->expectException( 'WP_Notify_Runtime_Exception' );
 		new WP_Notify_Recipient_Collection( $invalid_recipient );
 	}
 
 	public function data_provider_it_throws_on_invalid_type() {
-		$mock_recipient_1 = $this->createMock('WP_Notify_Recipient');
-		$mock_recipient_2 = $this->createMock('WP_Notify_Recipient');
+		$mock_recipient_1 = $this->createMock( 'WP_Notify_Recipient' );
+		$mock_recipient_2 = $this->createMock( 'WP_Notify_Recipient' );
 
 		return array(
 			array( null ),

--- a/tests/phpunit/tests/test-wp-notify-role-recipient.php
+++ b/tests/phpunit/tests/test-wp-notify-role-recipient.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_Role_Recipient extends WPNotify_TestCase {
+class Test_WP_Notify_Role_Recipient extends WP_Notify_TestCase {
 
 	public function test_it_can_be_instantiated() {
 		$testee = new WP_Notify_Role_Recipient( 1 );

--- a/tests/phpunit/tests/test-wp-notify-user-recipient.php
+++ b/tests/phpunit/tests/test-wp-notify-user-recipient.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WP_Notify_User_Recipient extends WPNotify_TestCase {
+class Test_WP_Notify_User_Recipient extends WP_Notify_TestCase {
 
 	public function test_it_can_be_instantiated() {
 		$testee = new WP_Notify_User_Recipient( 1 );
@@ -19,7 +19,7 @@ class Test_WP_Notify_User_Recipient extends WPNotify_TestCase {
 
 	/** @dataProvider data_provider_it_throws_on_invalid_type */
 	public function test_it_throws_on_invalid_type( $invalid_user_id ) {
-		$this->expectException('WP_Notify_Invalid_Recipient');
+		$this->expectException( 'WP_Notify_Invalid_Recipient' );
 		new WP_Notify_User_Recipient( $invalid_user_id );
 	}
 


### PR DESCRIPTION
## Goal

This PR sets up a workflow for Continuous Integration of our PHP code using GitHub Actions.

Each time a pull request is made on our `develop` and `trunk` branches:

-  automatically check the WordPress Code Standards 
-  run our PHP unit tests 

See #10 
Replaces #54 

## Details

- Inspired by [woccommerce/woocommerce](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/pr-unit-tests.yml)
- Uses [shivammathur/setup-php](https://github.com/shivammathur/setup-php)
- Uses [WPCS GitHub Action](https://github.com/10up/wpcs-action) from 10up (thanks @dinhtungdu)
- Uses the `install-wp-tests.sh` script created by the [wp scaffold plugin-tests]( [wp scaffold plugin-tests](https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/) ) command.

## Note

You may be able to run the Github Actions on your computer with [act](https://github.com/nektos/act), but you probably need the full installation of `nektos/act` to have SVN available... (takes lots of disk space)