### PR TITLE
Extend notification model with optional fields (redone)

### DIFF
--- a/includes/class-wp-notify-action-link.php
+++ b/includes/class-wp-notify-action-link.php
@@ -1,0 +1,27 @@
+<?php
+
+class WP_Notify_Action_Link implements JsonSerializable, WP_Notify_Json_Unserializable {
+
+	/**
+	 * WP_Notify_Action_Link constructor.
+	 *
+	 * @param string $url
+	 * @param string $text
+	 */
+	public function __construct( $url, $text ) {
+		$this->url  = $url;
+		$this->text = $text;
+	}
+
+	public function jsonSerialize() {
+		return array(
+			'url'  => $this->url,
+			'text' => $this->text,
+		);
+	}
+
+	public static function json_unserialize( $json ) {
+		$data = json_decode( $json );
+		return new WP_Notify_Action_Link( $data->url, $data->text );
+	}
+}

--- a/includes/class-wp-notify-composite-notification.php
+++ b/includes/class-wp-notify-composite-notification.php
@@ -32,8 +32,12 @@ class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification {
 		);
 	}
 
-	public function add( $name, $value ) {
+	public function add_field( $name, $value ) {
 		$this->additional_fields[ $name ] = $value;
+	}
+
+	public function add_fields( $fields ) {
+		$this->additional_fields = array_merge( $this->additional_fields, $fields );
 	}
 
 	public function get_field( $name ) {
@@ -54,11 +58,11 @@ class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification {
 
 		foreach ( json_decode( $json ) as $name => $value ) {
 			if ( WP_Notify_Composite_Notification::FIELD_TITLE === $name ) {
-				$composite_notification->add( $name, $value );
+				$composite_notification->add_field( $name, $value );
 			} elseif ( WP_Notify_Composite_Notification::FIELD_IMAGE === $name ) {
-				$composite_notification->add( $name, WP_Notify_Base_Image::json_unserialize( json_encode( $value ) ) );
+				$composite_notification->add_field( $name, WP_Notify_Base_Image::json_unserialize( json_encode( $value ) ) );
 			} elseif ( WP_Notify_Composite_Notification::FIELD_ACTION_LINK === $name ) {
-				$composite_notification->add( $name, WP_Notify_Action_Link::json_unserialize( json_encode( $value ) ) );
+				$composite_notification->add_field( $name, WP_Notify_Action_Link::json_unserialize( json_encode( $value ) ) );
 			}
 		}
 

--- a/includes/class-wp-notify-composite-notification.php
+++ b/includes/class-wp-notify-composite-notification.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class WP_Notify_Composite_Notification
+ *
+ * Allows a notification to be extended with optional fields
+ */
+class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification
+{
+    const FIELD_TITLE = 'title';
+
+    private $additional_fields = array();
+
+    public function add( $name, $value ) {
+        $this->additional_fields[ $name ] = $value;
+    }
+
+    public function jsonSerialize()
+    {
+        return array_merge(
+            parent::jsonSerialize(),
+            $this->additional_fields
+        );
+    }
+}

--- a/includes/class-wp-notify-composite-notification.php
+++ b/includes/class-wp-notify-composite-notification.php
@@ -8,6 +8,7 @@
 class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification {
 
 	const FIELD_TITLE = 'title';
+	const FIELD_IMAGE = 'WP_Notify_Base_Image';
 
 	/**
 	 * Associative array, keys must match the class FIELD_* constants.
@@ -53,6 +54,8 @@ class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification {
 		foreach ( json_decode( $json ) as $name => $value ) {
 			if ( WP_Notify_Composite_Notification::FIELD_TITLE === $name ) {
 				$composite_notification->add( $name, $value );
+			} elseif ( WP_Notify_Composite_Notification::FIELD_IMAGE === $name ) {
+				$composite_notification->add( $name, WP_Notify_Base_Image::json_unserialize( json_encode( $value ) ) );
 			}
 		}
 

--- a/includes/class-wp-notify-composite-notification.php
+++ b/includes/class-wp-notify-composite-notification.php
@@ -33,11 +33,20 @@ class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification {
 	}
 
 	public function add_field( $name, $value ) {
+		$class        = __CLASS__;
+		$reflection   = new ReflectionClass( $class );
+		$valid_fields = $reflection->getConstants();
+		if ( ! in_array( $name, $valid_fields, true ) ) {
+			throw new InvalidArgumentException( "'{$name}' is not a valid {$class} additional field type." );
+		}
+
 		$this->additional_fields[ $name ] = $value;
 	}
 
 	public function add_fields( $fields ) {
-		$this->additional_fields = array_merge( $this->additional_fields, $fields );
+		foreach ( $fields as $name => $value ) {
+			$this->add_field( $name, $value );
+		}
 	}
 
 	public function get_field( $name ) {

--- a/includes/class-wp-notify-composite-notification.php
+++ b/includes/class-wp-notify-composite-notification.php
@@ -5,21 +5,57 @@
  *
  * Allows a notification to be extended with optional fields
  */
-class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification
-{
-    const FIELD_TITLE = 'title';
+class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification {
 
-    private $additional_fields = array();
+	const FIELD_TITLE = 'title';
 
-    public function add( $name, $value ) {
-        $this->additional_fields[ $name ] = $value;
-    }
+	/**
+	 * Associative array, keys must match the class FIELD_* constants.
+	 *
+	 * @var array
+	 */
+	private $additional_fields = array();
 
-    public function jsonSerialize()
-    {
-        return array_merge(
-            parent::jsonSerialize(),
-            $this->additional_fields
-        );
-    }
+	/**
+	 * @param WP_Notify_Notification $notification
+	 * @return WP_Notify_Composite_Notification
+	 */
+	public static function from_notification( $notification ) {
+		return new self(
+			$notification->get_sender(),
+			$notification->get_recipients(),
+			$notification->get_message(),
+			$notification->get_timestamp(),
+			$notification->get_id()
+		);
+	}
+
+	public function add( $name, $value ) {
+		$this->additional_fields[ $name ] = $value;
+	}
+
+	public function get_field( $name ) {
+		if ( array_key_exists( $name, $this->additional_fields ) ) {
+			return $this->additional_fields[ $name ];
+		}
+	}
+
+	public function jsonSerialize() {
+		return array_merge(
+			parent::jsonSerialize(),
+			$this->additional_fields
+		);
+	}
+
+	public static function json_unserialize( $json ) {
+		$composite_notification = self::from_notification( parent::json_unserialize( $json ) );
+
+		foreach ( json_decode( $json ) as $name => $value ) {
+			if ( WP_Notify_Composite_Notification::FIELD_TITLE === $name ) {
+				$composite_notification->add( $name, $value );
+			}
+		}
+
+		return $composite_notification;
+	}
 }

--- a/includes/class-wp-notify-composite-notification.php
+++ b/includes/class-wp-notify-composite-notification.php
@@ -7,8 +7,9 @@
  */
 class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification {
 
-	const FIELD_TITLE = 'title';
-	const FIELD_IMAGE = 'WP_Notify_Base_Image';
+	const FIELD_TITLE       = 'title';
+	const FIELD_IMAGE       = 'WP_Notify_Base_Image';
+	const FIELD_ACTION_LINK = 'WP_Notify_Action_Link';
 
 	/**
 	 * Associative array, keys must match the class FIELD_* constants.
@@ -56,6 +57,8 @@ class WP_Notify_Composite_Notification extends WP_Notify_Base_Notification {
 				$composite_notification->add( $name, $value );
 			} elseif ( WP_Notify_Composite_Notification::FIELD_IMAGE === $name ) {
 				$composite_notification->add( $name, WP_Notify_Base_Image::json_unserialize( json_encode( $value ) ) );
+			} elseif ( WP_Notify_Composite_Notification::FIELD_ACTION_LINK === $name ) {
+				$composite_notification->add( $name, WP_Notify_Action_Link::json_unserialize( json_encode( $value ) ) );
 			}
 		}
 

--- a/tests/data/notification-title-image-link.json
+++ b/tests/data/notification-title-image-link.json
@@ -1,0 +1,15 @@
+{
+    "WP_Notify_Recipient_Collection": [],
+    "WP_Notify_Base_Message": "WordPress was successfully updated to version 5.6.",
+    "WP_Notify_Base_Sender": {
+        "name": "WordPress"
+    },
+    "title": "WordPress",
+    "WP_Notify_Base_Image": {
+        "source": "/path/to/my/iamge.jpg"
+    },
+    "WP_Notify_Action_Link": {
+        "url": "#",
+        "text": "Read what's new in 5.6"
+    }
+}

--- a/tests/data/notification-with-action-link.json
+++ b/tests/data/notification-with-action-link.json
@@ -1,0 +1,11 @@
+{
+  "WP_Notify_Recipient_Collection": [],
+  "WP_Notify_Base_Message": "WordPress was successfully updated to version 5.6.",
+  "WP_Notify_Base_Sender": {
+    "name": "WordPress"
+  },
+  "WP_Notify_Action_Link": {
+    "url": "#",
+    "text": "Read what's new in 5.6"
+  }
+}

--- a/tests/data/notification-with-image.json
+++ b/tests/data/notification-with-image.json
@@ -1,0 +1,10 @@
+{
+  "WP_Notify_Recipient_Collection": [],
+  "WP_Notify_Base_Message": "WordPress was successfully updated to version 5.6.",
+  "WP_Notify_Base_Sender": {
+    "name": "WordPress"
+  },
+  "WP_Notify_Base_Image": {
+    "source": "\/path\/to\/my\/image.jpg"
+  }
+}

--- a/tests/data/notification-with-title.json
+++ b/tests/data/notification-with-title.json
@@ -1,0 +1,8 @@
+{
+  "WP_Notify_Recipient_Collection": [],
+  "WP_Notify_Base_Message": "WordPress was successfully updated to version 5.6.",
+  "WP_Notify_Base_Sender": {
+    "name":"WordPress"
+  },
+  "title": "WordPress"
+}

--- a/tests/phpunit/tests/test-wp-notify-action-link.php
+++ b/tests/phpunit/tests/test-wp-notify-action-link.php
@@ -1,0 +1,30 @@
+<?php
+
+class Test_WP_Notify_Action_Link extends WPNotify_TestCase {
+
+	public function test_it_can_be_serialized() {
+		$testee = new WP_Notify_Action_Link( '#', 'Read more' );
+
+		$result = json_encode( $testee );
+
+		$this->assertJsonStringEqualsJsonString(
+			'{
+                "url": "#",
+                "text": "Read more"
+            }',
+			$result
+		);
+	}
+
+	public function test_it_can_be_unserialized() {
+		$json_data = '{
+            "url": "#",
+            "text": "Read more"
+        }';
+
+		$result = WP_Notify_Action_Link::json_unserialize( $json_data );
+
+		$this->assertInstanceOf( WP_Notify_Action_Link::class, $result );
+		$this->assertEquals( new WP_Notify_Action_Link( '#', 'Read more' ), $result );
+	}
+}

--- a/tests/phpunit/tests/test-wp-notify-composite-notification.php
+++ b/tests/phpunit/tests/test-wp-notify-composite-notification.php
@@ -20,12 +20,11 @@ class Test_WP_Notify_Composite_Notification extends WPNotify_TestCase {
 
 	/**
 	 * @dataProvider json_encoded_notifications_provider
-	 * @param string $field_name
-	 * @param mixed $field_value
+	 * @param array $fields Associative array of fields to add.
 	 * @param string $json_file
 	 */
-	public function test_it_can_be_json_encoded_with_additional_fields( $field_name, $field_value, $json_file ) {
-		$this->composite_notification->add( $field_name, $field_value );
+	public function test_it_can_be_json_encoded_with_additional_fields( $fields, $json_file ) {
+		$this->composite_notification->add_fields( $fields );
 
 		$result = json_encode( $this->composite_notification );
 
@@ -37,36 +36,42 @@ class Test_WP_Notify_Composite_Notification extends WPNotify_TestCase {
 
 	/**
 	 * @dataProvider json_encoded_notifications_provider
-	 * @param string $field_name
-	 * @param mixed $field_value
+	 * @param array $fields Associative array of fields to add.
 	 * @param string $json_file
 	 */
-	public function test_it_can_be_instantiated_from_json_with_additonal_fields( $field_name, $field_value, $json_file ) {
+	public function test_it_can_be_instantiated_from_json_with_additonal_fields( $fields, $json_file ) {
 		$result = WP_Notify_Composite_Notification::json_unserialize( file_get_contents( $json_file ) );
 
 		$this->assertInstanceOf( WP_Notify_Composite_Notification::class, $result );
 		$this->assertEquals( 'WordPress', $result->get_sender()->get_name() );
 		$this->assertInstanceOf( WP_Notify_Recipient_Collection::class, $result->get_recipients() );
 		$this->assertEquals( 'WordPress was successfully updated to version 5.6.', $result->get_message()->get_content() );
-		$this->assertEquals( $field_value, $result->get_field( $field_name ) );
+		$additional_fields = new ReflectionProperty( WP_Notify_Composite_Notification::class, 'additional_fields' );
+		$additional_fields->setAccessible( true );
+		$this->assertEqualSets( $fields, $additional_fields->getValue( $result ) );
 	}
 
 	public function json_encoded_notifications_provider() {
 		return array(
-			array(
-				'field_name'  => WP_Notify_Composite_Notification::FIELD_TITLE,
-				'field_value' => 'WordPress',
-				'json_file'   => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-title.json',
+			'With title'                        => array(
+				'fields'    => array( WP_Notify_Composite_Notification::FIELD_TITLE => 'WordPress' ),
+				'json_file' => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-title.json',
 			),
-			array(
-				'field_name'  => WP_Notify_Composite_Notification::FIELD_IMAGE,
-				'field_value' => new WP_Notify_Base_Image( '/path/to/my/image.jpg' ),
-				'json_file'   => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-image.json',
+			'With image'                        => array(
+				'fields'    => array( WP_Notify_Composite_Notification::FIELD_IMAGE => new WP_Notify_Base_Image( '/path/to/my/image.jpg' ) ),
+				'json_file' => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-image.json',
 			),
-			array(
-				'field_name'  => WP_Notify_Composite_Notification::FIELD_ACTION_LINK,
-				'field_value' => new WP_Notify_Action_Link( '#', "Read what's new in 5.6" ),
-				'json_file'   => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-action-link.json',
+			'With action link'                  => array(
+				'fields'    => array( WP_Notify_Composite_Notification::FIELD_ACTION_LINK => new WP_Notify_Action_Link( '#', "Read what's new in 5.6" ) ),
+				'json_file' => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-action-link.json',
+			),
+			'With title, image and action link' => array(
+				'fields'    => array(
+					WP_Notify_Composite_Notification::FIELD_TITLE => 'WordPress',
+					WP_Notify_Composite_Notification::FIELD_IMAGE => new WP_Notify_Base_Image( '/path/to/my/iamge.jpg' ),
+					WP_Notify_Composite_Notification::FIELD_ACTION_LINK => new WP_Notify_Action_Link( '#', "Read what's new in 5.6" ),
+				),
+				'json_file' => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-title-image-link.json',
 			),
 		);
 	}

--- a/tests/phpunit/tests/test-wp-notify-composite-notification.php
+++ b/tests/phpunit/tests/test-wp-notify-composite-notification.php
@@ -1,32 +1,46 @@
 <?php
 
 
-class Test_WP_Notify_Composite_Notification extends WPNotify_TestCase
-{
-    /**
-     * @var WP_Notify_Composite_Notification
-     */
-    private $testee;
+class Test_WP_Notify_Composite_Notification extends WPNotify_TestCase {
 
-    public function setUp()
-    {
-        parent::setUp();
+	/**
+	 * @var WP_Notify_Composite_Notification
+	 */
+	private $composite_notification;
 
-        $this->testee = new WP_Notify_Composite_Notification(
-            new WP_Notify_Base_Sender( 'WordPress' ),
-            new WP_Notify_Recipient_Collection(),
-            new WP_Notify_Base_Message( 'WordPress was successfully updated to version 5.6.' )
-        );
-    }
+	public function setUp() {
+		parent::setUp();
 
-    public function test_it_can_be_json_encoded_with_a_title() {
-       $this->testee->add( WP_Notify_Composite_Notification::FIELD_TITLE, 'WordPress');
+		$this->composite_notification = new WP_Notify_Composite_Notification(
+			new WP_Notify_Base_Sender( 'WordPress' ),
+			new WP_Notify_Recipient_Collection(),
+			new WP_Notify_Base_Message( 'WordPress was successfully updated to version 5.6.' )
+		);
+	}
 
-        $result = json_encode( $this->testee );
+	public function test_it_can_be_json_encoded_with_a_title() {
+		$this->composite_notification->add( WP_Notify_Composite_Notification::FIELD_TITLE, 'WordPress' );
 
-        $this->assertJsonStringEqualsJsonFile(
-            WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-title.json',
-            $result
-        );
-    }
+		$result = json_encode( $this->composite_notification );
+
+		$this->assertJsonStringEqualsJsonFile(
+			WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-title.json',
+			$result
+		);
+	}
+
+	public function test_it_can_be_instantiated_from_json_with_a_title() {
+		$this->composite_notification->add(
+			WP_Notify_Composite_Notification::FIELD_TITLE,
+			'WordPress'
+		);
+
+		$testee = WP_Notify_Composite_Notification::json_unserialize( file_get_contents( WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-title.json' ) );
+
+		$this->assertInstanceOf( WP_Notify_Notification::class, $testee );
+		$this->assertEquals( 'WordPress', $testee->get_sender()->get_name() );
+		$this->assertInstanceOf( WP_Notify_Recipient_Collection::class, $testee->get_recipients() );
+		$this->assertEquals( 'WordPress was successfully updated to version 5.6.', $testee->get_message()->get_content() );
+		$this->assertEquals( 'WordPress', $testee->get_field( WP_Notify_Composite_Notification::FIELD_TITLE ) );
+	}
 }

--- a/tests/phpunit/tests/test-wp-notify-composite-notification.php
+++ b/tests/phpunit/tests/test-wp-notify-composite-notification.php
@@ -75,4 +75,24 @@ class Test_WP_Notify_Composite_Notification extends WPNotify_TestCase {
 			),
 		);
 	}
+
+	public function test_it_cannot_accept_an_unregistered_field_type() {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( "'user' is not a valid WP_Notify_Composite_Notification additional field type." );
+
+		$this->composite_notification->add_field( 'user', 'totoro' );
+	}
+
+	public function test_it_cannot_accept_an_unregistered_field_type_in_an_array() {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( "'user' is not a valid WP_Notify_Composite_Notification additional field type." );
+
+		$this->composite_notification->add_fields(
+			array(
+				WP_Notify_Composite_Notification::FIELD_TITLE => 'WordPress',
+				'user' => 'totore',
+				WP_Notify_Composite_Notification::FIELD_IMAGE => new WP_Notify_Base_Image( '/path/to/my/image.jpg' ),
+			)
+		);
+	}
 }

--- a/tests/phpunit/tests/test-wp-notify-composite-notification.php
+++ b/tests/phpunit/tests/test-wp-notify-composite-notification.php
@@ -1,0 +1,32 @@
+<?php
+
+
+class Test_WP_Notify_Composite_Notification extends WPNotify_TestCase
+{
+    /**
+     * @var WP_Notify_Composite_Notification
+     */
+    private $testee;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->testee = new WP_Notify_Composite_Notification(
+            new WP_Notify_Base_Sender( 'WordPress' ),
+            new WP_Notify_Recipient_Collection(),
+            new WP_Notify_Base_Message( 'WordPress was successfully updated to version 5.6.' )
+        );
+    }
+
+    public function test_it_can_be_json_encoded_with_a_title() {
+       $this->testee->add( WP_Notify_Composite_Notification::FIELD_TITLE, 'WordPress');
+
+        $result = json_encode( $this->testee );
+
+        $this->assertJsonStringEqualsJsonFile(
+            WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-title.json',
+            $result
+        );
+    }
+}

--- a/tests/phpunit/tests/test-wp-notify-composite-notification.php
+++ b/tests/phpunit/tests/test-wp-notify-composite-notification.php
@@ -63,6 +63,11 @@ class Test_WP_Notify_Composite_Notification extends WPNotify_TestCase {
 				'field_value' => new WP_Notify_Base_Image( '/path/to/my/image.jpg' ),
 				'json_file'   => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-image.json',
 			),
+			array(
+				'field_name'  => WP_Notify_Composite_Notification::FIELD_ACTION_LINK,
+				'field_value' => new WP_Notify_Action_Link( '#', "Read what's new in 5.6" ),
+				'json_file'   => WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/tests/data/notification-with-action-link.json',
+			),
 		);
 	}
 }

--- a/wp-notify.php
+++ b/wp-notify.php
@@ -19,6 +19,8 @@ require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/interface-wp-notify-
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/class-wp-notify-factory.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/class-wp-notify-aggregate-factory.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/class-wp-notify-base-notification.php';
+require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/class-wp-notify-composite-notification.php';
+require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/class-wp-notify-action-link.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/image/interface-wp-notify-image.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/image/class-wp-notify-base-image.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/senders/interface-wp-notify-sender.php';


### PR DESCRIPTION
## Before


The `WP_Notify_Base_Notification` model was not up-to-date with the optional fields defined in PR #21

See #60 

## Changes

- Introduces a 'composite notification' model that can take additional fields
    - `FIELD_TITLE`
    - `FIELD_IMAGE`
    - `FIELD_ACTION_LINK`
- Serializes the notifications with the optional fields into JSON
- Unserializes notifications with optional fields from JSON

Replaces #61

## TODO

- [x] Test serializing and unserializing notifications with several of the optional fields
- [ ] Refactor `WP_Notify_Composite_Notification::json_unserialize()` to not encode and decode JSON data many times
- [ ] (Maybe) Merge the `WP_Notify_Composite_Notification` with the `WP_Notify_Base_Notification` model