### PR TITLE
Add readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,29 @@
+=== Plugin Name ===
+Contributors: schlessera, psykro, raaaahman, danbilauca
+Tags: feature-notifications
+Requires at least: 5.0
+Tested up to: 6.0
+Requires PHP: 7.4
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A new (better) way to manage and deliver WordPress notifications to the relevant audience.
+
+== Description ==
+
+1. Allow WordPress core to send notifications to administrative users to give them feedback about changes in the system.
+1. Allow plugin and theme authors to send notifications to administrative users to give them feedback about changes in the system
+1. Prevent plugin and theme authors from abusing this notification system in “spammy” ways.
+1. Allow WordPress users who have access to notifications to control which, how, and where they receive them.
+
+Want to contribute, checkout the code [on GitHug](https://github.com/WordPress/wp-feature-notifications) and read more about the projects goals on our [wiki](https://github.com/WordPress/wp-feature-notifications/wiki).
+
+== Screenshots ==
+
+== Changelog ==
+
+= 0.0.1 =
+* Initial Release
+
+
+


### PR DESCRIPTION
Add readme.txt for WordPress.org plugin repository submission.

Please comment on this PR with your own WordPress org profile name to be added.