### PR TITLE
Avoid issues with phpcs

### DIFF
--- a/includes/restapi/class-wp-notify-notification-controller.php
+++ b/includes/restapi/class-wp-notify-notification-controller.php
@@ -1,0 +1,5 @@
+<?php
+
+interface WP_Notify_Notification_Controller {
+
+}


### PR DESCRIPTION
The fully empty file creates troubles with phpcs (and conseguently with commit hooks)... I created an empty class into "includes/restapi/class-wp-notify-notification-controller.php" to overcome the issue