### PR TITLE
Disables notification hub visibility clicking on page body

### DIFF
--- a/src/scripts/wp-notify.js
+++ b/src/scripts/wp-notify.js
@@ -5,15 +5,27 @@ import wpLogo from "../images/wl.svg";
 // delay util function
 const delay = (ms) => new Promise((f) => setTimeout(f, ms));
 
+/**
+ * Toggle notification hub
+ */
+const wpNotifyHub = document.getElementById("wp-admin-bar-wp-notify");
+
+const disableNotifyDrawer = () => {
+  wpNotifyHub.classList.remove("active");
+  document.body.removeEventListener("click", disableNotifyDrawer);
+};
+
 // handle click on wp-admin bar bell icon that show the WP-Notify sidebar
-document
-  .getElementById("wp-admin-bar-wp-notify")
-  .addEventListener("click", function () {
-    this.classList.toggle("active");
-  });
+wpNotifyHub.addEventListener("click", function (e) {
+  e.stopPropagation();
+  if (!wpNotifyHub.classList.contains("active")) {
+    this.classList.add("active");
+    document.body.addEventListener("click", disableNotifyDrawer);
+  }
+});
 
 /**
- * enable the main dash notifications if available
+ * Enable the main dash notifications if available
  */
 const notifyWrapper = document.getElementById("wp-notify-dashboard-notices");
 if (notifyWrapper) {


### PR DESCRIPTION
FIX: https://github.com/WordPress/wp-feature-notifications/pull/67#issuecomment-1143089828

> Does anyone else think that clicking outside of the drawer-style sidebar should make it disappear? That's a pretty common pattern and I don't see any other UI element to close the sidebar. (@bacoords)

> Personally as a user, that's definitely the behaviour I'd expect it to have. (@Sephsekla)

Creates a click event listener on body when the drawer is open, when triggered it closes the drawer and remove the listener