### PR TITLE
adds basic responsive styles

### DIFF
--- a/src/styles/notify/admin-bar.scss
+++ b/src/styles/notify/admin-bar.scss
@@ -53,7 +53,7 @@
   }
 
   /* Mobile */
-  @media screen and (max-width: 782px) {
+  @media #{$breakpoint} {
     display: block;
     .ab-label {
       clip: unset;

--- a/src/styles/notify/admin-bar.scss
+++ b/src/styles/notify/admin-bar.scss
@@ -1,6 +1,7 @@
 /*
  * WP admin bar
  */
+
 #wpadminbar #wp-admin-bar-wp-notify {
   padding-right: 8px;
   position: relative;
@@ -51,4 +52,16 @@
     }
   }
 
+  /* Mobile */
+  @media screen and (max-width: 782px) {
+    display: block;
+    .ab-label {
+      clip: unset;
+      clip-path: unset;
+      width: 11px;
+      height: 11px;
+      top: 16px;
+      left: 28px;
+    }
+  }
 }

--- a/src/styles/notify/notification-hub.scss
+++ b/src/styles/notify/notification-hub.scss
@@ -109,6 +109,9 @@
     .ab-icon:before {
       color: var(--wp-notify_color-link);
     }
+    @media screen and ( max-width:782px ) {
+      line-height: 40px;
+    }
   }
 
   #wpadminbar .quicklinks & a {

--- a/src/styles/notify/notification-hub.scss
+++ b/src/styles/notify/notification-hub.scss
@@ -109,7 +109,7 @@
     .ab-icon:before {
       color: var(--wp-notify_color-link);
     }
-    @media screen and ( max-width:782px ) {
+    @media #{$breakpoint} {
       line-height: 40px;
     }
   }

--- a/src/styles/notify/notify.scss
+++ b/src/styles/notify/notify.scss
@@ -84,5 +84,12 @@
       object-position: center;
       object-fit: contain;
     }
+
+    @media screen and ( max-width:782px ) {
+      grid-template-columns: auto;
+      .wp-notification-wrap{
+        order: 2
+      }
+    }
   }
 }

--- a/src/styles/notify/notify.scss
+++ b/src/styles/notify/notify.scss
@@ -85,7 +85,7 @@
       object-fit: contain;
     }
 
-    @media screen and ( max-width:782px ) {
+    @media #{$breakpoint} {
       grid-template-columns: auto;
       .wp-notification-wrap{
         order: 2

--- a/src/styles/notify/vars.scss
+++ b/src/styles/notify/vars.scss
@@ -26,3 +26,6 @@
   --wp-notify_hub-spacing-horizontal: 24px;
   --wp-notify_hub-element-spacing: 8px;
 }
+
+// Mobile breakpoint used in wp-admin.
+$breakpoint: 'screen and (max-width: 782px)';


### PR DESCRIPTION
This branch has a few updates to get the mobile styles passable for the notifications / hub. 

For now I just stacked the images above the title, but I'm sure there's a cool CSS grid way to get the image under the title but above the content? At this point because the notifications are one giant block it gets a little unclear which notification the image belongs to.

I left the settings page alone on mobile because honestly I didn't know where to start.