### PR TITLE
adds basic templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Report a bug with WP Feature Notifications
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report! If this is a security issue, please report it in HackerOne instead: https://hackerone.com/wordpress
+    - type: textarea
+      attributes:
+          label: Description
+          description: Please write a brief description of the bug, including what you expect to happen and what is currently happening.
+          placeholder: |
+              Feature '...' is not working properly. I expect '...' to happen, but '...' happens instead
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Step-by-step reproduction instructions
+          description: Please write the steps needed to reproduce the bug.
+          placeholder: |
+              1. Go to '...'
+              2. Click on '...'
+              3. Scroll down to '...'
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Screenshots, screen recording, code snippet
+          description: |
+              If possible, please upload a screenshot or screen recording which demonstrates the bug. You can use LIEcap to create a GIF screen recording: https://www.cockos.com/licecap/
+              Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+              If this bug is to related to a developer API, please share a code snippet that demonstrates the issue. For small snippets paste it directly here, or you can use GitHub Gist to share multiple code files: https://gist.github.com
+              Please ensure the shared code can be used by a developer to reproduce the issue—ideally it can be copied into a local development environment or executed in a browser console to help debug the issue
+      validations:
+          required: false
+
+    - type: textarea
+      attributes:
+          label: Environment info
+          description: |
+              Please list what WP Feature Notifications version you are using. If you aren't using WP Feature Notifications, please note that it's not installed.
+          placeholder: |
+              - WordPress version, WP Feature Notifications version, and active Theme you are using.
+              - Browser(s) are you seeing the problem on.
+              - Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.).
+      validations:
+          required: false
+
+    - type: dropdown
+      id: existing
+      attributes:
+          label: Please confirm that you have searched existing issues in the repo.
+          description: You can do this by searching https://github.com/WordPress/wp-feature-notifications/issues and making sure the bug is not related to another plugin.
+          multiple: true
+          options:
+              - 'Yes'
+              - 'No'
+      validations:
+          required: true
+
+    - type: dropdown
+      id: plugins
+      attributes:
+          label: Please confirm that you have tested with all plugins deactivated except WP Feature Notifications.
+          multiple: true
+          options:
+              - 'Yes'
+              - 'No'
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -32,7 +32,7 @@ body:
               If possible, please upload a screenshot or screen recording which demonstrates the bug. You can use LIEcap to create a GIF screen recording: https://www.cockos.com/licecap/
               Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
               If this bug is to related to a developer API, please share a code snippet that demonstrates the issue. For small snippets paste it directly here, or you can use GitHub Gist to share multiple code files: https://gist.github.com
-              Please ensure the shared code can be used by a developer to reproduce the issue—ideally it can be copied into a local development environment or executed in a browser console to help debug the issue
+              Please ensure the shared code can be used by a developer to reproduce the issue — ideally it can be copied into a local development environment or executed in a browser console to help debug the issue.
       validations:
           required: false
 
@@ -40,11 +40,12 @@ body:
       attributes:
           label: Environment info
           description: |
-              Please list what WP Feature Notifications version you are using. If you aren't using WP Feature Notifications, please note that it's not installed.
+              Please list what WP Feature Notifications version you are using.
           placeholder: |
               - WordPress version, WP Feature Notifications version, and active Theme you are using.
               - Browser(s) are you seeing the problem on.
               - Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.).
+              - Any other active plugins and your hosting environment (if applicable)
       validations:
           required: false
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Propose an idea for a feature or an enhancement
+
+---
+
+## What problem does this address?
+<!--
+Please describe if this feature or enhancement is related to a current problem
+or pain point. For example, "I'm always frustrated when ..." or "It is currently
+difficult to ...".
+-->
+
+## What is your proposed solution?
+<!--
+Please outline the feature or enhancement that you want and how it addresses any
+problem identified above.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,8 @@ https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions --
 <!-- In a few words, what is the PR actually doing? -->
 
 ## Why?
-<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
+<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
+https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
 
 ## How?
 <!-- How is your PR addressing the issue at hand? What are the implementation details? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
+https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->
+
+## What?
+<!-- In a few words, what is the PR actually doing? -->
+
+## Why?
+<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
+
+## How?
+<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
+
+## Testing Instructions
+<!-- Please include step by step instructions on how to test this PR. -->
+<!-- 1. Open a Post or Page. -->
+<!-- 2. Insert a Heading Block. -->
+<!-- 3. etc. -->
+
+## Screenshots or screencast <!-- if applicable -->


### PR DESCRIPTION
This PR adds some basic templates:

- Feature Request
- Bug Report
- PR template

along with a basic config file. I'm actually not sure how to test this without it going live, though I could maybe fork the branch to a new personal repo, if we think that could be helpful. 