### PR TITLE
Add demo REST controller

### DIFF
--- a/includes/restapi/class-notification-controller.php
+++ b/includes/restapi/class-notification-controller.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * REST API controller to get and set notifications.
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\REST;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * REST API Controller class
+ */
+class Notification_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST endpoint.
+	 *
+	 * @type string
+	 */
+	const NAMESPACE = 'wp/v2';
+
+	/**
+	 * Base for notification REST routes.
+	 *
+	 * @type string
+	 */
+	const NOTIFICATION_BASE = 'notifications';
+
+	public function __construct()
+	{
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+
+	/**
+	 * Register REST routes
+	 *
+	 * @return void
+	 */
+	public function register_routes() : void {
+		register_rest_route(
+			self::NAMESPACE,
+			self::NOTIFICATION_BASE,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'args'                => array(),
+				'callback'            => array( $this, 'get_notifications' ),
+				'permission_callback' => array( $this, 'authenticate' ),
+			),
+			false,
+		);
+	}
+
+	/**
+	 * Authenticate notification request.
+	 *
+	 * @return boolean true if authenticated, false otherwise.
+	 */
+	public function authenticate() : bool {
+		// TODO: Implement authentication.
+		return true;
+	}
+
+	/**
+	 * Get notifications for request.
+	 *
+	 * @param WP_REST_Request $request Recieved REST request
+	 *
+	 * @return WP_REST_RESPONSE|WP_Error REST response or WP Error
+	 */
+	public function get_notifications( $request ) {
+		$demo_data = file_get_contents( dirname( __FILE__ ) . 'fake_api.json' );
+
+		if ( empty( $demo_data ) ) {
+			return new WP_Error( 'demo', __( 'Could not read demo data.' ) );
+		}
+
+		return rest_ensure_response( $demo_data );
+	}
+}

--- a/includes/restapi/class-notification-controller.php
+++ b/includes/restapi/class-notification-controller.php
@@ -37,7 +37,6 @@ class Notification_Controller extends WP_REST_Controller {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
-
 	/**
 	 * Register REST routes
 	 *

--- a/includes/restapi/class-notification-controller.php
+++ b/includes/restapi/class-notification-controller.php
@@ -74,12 +74,12 @@ class Notification_Controller extends WP_REST_Controller {
 	 * @return WP_REST_RESPONSE|WP_Error REST response or WP Error
 	 */
 	public function get_notifications( $request ) {
-		$demo_data = file_get_contents( dirname( __FILE__ ) . 'fake_api.json' );
+		$demo_data = file_get_contents( dirname( __FILE__ ) . '/fake_api.json' );
 
 		if ( empty( $demo_data ) ) {
 			return new WP_Error( 'demo', __( 'Could not read demo data.' ) );
 		}
 
-		return rest_ensure_response( $demo_data );
+		return rest_ensure_response( json_decode( $demo_data ) );
 	}
 }

--- a/includes/restapi/class-notification-controller.php
+++ b/includes/restapi/class-notification-controller.php
@@ -32,8 +32,7 @@ class Notification_Controller extends WP_REST_Controller {
 	 */
 	const NOTIFICATION_BASE = 'notifications';
 
-	public function __construct()
-	{
+	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 

--- a/includes/restapi/class-notification-controller.php
+++ b/includes/restapi/class-notification-controller.php
@@ -51,7 +51,7 @@ class Notification_Controller extends WP_REST_Controller {
 				'callback'            => array( $this, 'get_notifications' ),
 				'permission_callback' => array( $this, 'authenticate' ),
 			),
-			false,
+			false
 		);
 	}
 

--- a/includes/restapi/class-wp-notify-notification-controller.php
+++ b/includes/restapi/class-wp-notify-notification-controller.php
@@ -1,5 +1,0 @@
-<?php
-
-interface WP_Notify_Notification_Controller {
-
-}

--- a/includes/restapi/fake_api.json
+++ b/includes/restapi/fake_api.json
@@ -1,0 +1,141 @@
+[
+	{
+		"location": "dashboard",
+		"image": "https://raw.githubusercontent.com/erikyo/wp-notify/design_implementation/src/images/i.svg",
+		"title": "Try this new Notification feature",
+		"source": "#WP-Notify",
+		"date": 1664992015,		
+		"message": "We have just added a <b>wonderful feature!</b> <script>alert('xss')</script> You might want to give it a try so click on the bell icon on the right side of the adminbar.</div></div></div></div>",
+		"acceptMessage": "Try this new feature",
+		"acceptLink": "https://github.com/WordPress/wp-notify",
+		"dismissible": false
+	},
+	{
+		"location": "dashboard",
+		"image": "https://source.unsplash.com/random/400×400/?notify",
+		"title": "Message variant #1",
+		"date": 1654866071,
+		"message": "This is an example of on-page message variant #1. It has a title, a message, an image, an action button with a URL, is dismissable.",
+		"source": "#Test",
+		"dismissible": true,
+		"unread": true,
+		"acceptMessage": "TEST",
+		"acceptLink": "https://github.com/WordPress/wp-notify"
+	},
+	{
+		"title": "Message variant #1 (copy)",
+		"date": 1654866081,
+		"acceptMessage": "TEST",
+		"acceptLink": "https://github.com/WordPress/wp-notify"
+	},
+	{
+		"location": "adminbar",
+		"title": "Message variant #2",
+		"source": "#WP-Notify",
+		"date": 1654866091,
+		"message": "This is an example of on-page message variant #2. It has a title, a message, a custom date, an action button with a URL, is dismissable, but has no images.",
+		"acceptMessage": "OK",
+		"acceptLink": "https://github.com/WordPress/wp-notify",
+		"dismissible": true,
+		"unread": true
+	},
+	{
+		"location": "dashboard",
+		"image": "https://gifimage.net/wp-content/uploads/2018/10/animation-notification-gif-2.gif",
+		"date": 1654866101,
+		"title": "Message variant #3",
+		"message": "if you're wondering where notice #2 is try looking at the adminbar at the top right near the bell icon 😉.",
+		"acceptLink": "https://github.com/WordPress/wp-notify",
+		"dismissible": true,
+		"unread": true
+	},
+	
+	{
+		"title": "WordPress",
+		"message": "WordPress was successfully updated to version 6.1",
+		"acceptMessage": "Read what's new in 6.1",
+		"acceptLink": "#",
+		"unread": true,
+		"source": "WordPress",
+		"date": 1664992015
+	},
+	{
+		"message": "WordPress was successfully updated to version 5.9.",
+		"source": "WordPress",
+		"date": 1654866081
+	},
+	{
+		"title": "WordPress",
+		"message": "WordPress was successfully updated to version 6.1",
+		"acceptMessage": "Read what's new in 6.1",
+		"acceptLink": "#",
+		"source": "WordPress",
+		"date": 1654850000
+	},
+	{
+		"title": "WordPress",
+		"message": "WordPress was successfully updated to version 6.1",
+		"acceptMessage": "Read what's new in 6.1",
+		"acceptLink": "#",
+		"source": "WordPress",
+		"date": 1654840000
+	},
+	{
+		"image": "https://ps.w.org/contact-form-7/assets/icon-256x256.png",
+		"message": "There is a new version of Contact Form 7 available.",
+		"acceptMessage": "Update now",
+		"acceptLink": "#",
+		"source": "Plugins Updates",
+		"date": 1654830000
+	},
+	{
+		"image": "https://ps.w.org/akismet/assets/icon-256x256.png",
+		"title": "Akismet",
+		"acceptMessage": "Your API key is no longer valid.",
+		"acceptLink": "#",
+		"source": "Akismet",
+		"date": 1654820000
+	},
+	{
+		"icon": "ab-icon dashicons-paperclip",
+		"title": "Default",
+		"acceptLink": "#",
+		"source": "Wordpress",
+		"date": 1654800000
+	},
+	{
+		"severity": "alert",
+		"icon": "ab-icon dashicons-sos",
+		"title": "Site Health status",
+		"message": "Your site has critical issues that should be addressed",
+		"source": "Wordpress",
+		"date": 1654800000
+	},
+	{
+		"severity": "warning",
+		"icon": "ab-icon dashicons-admin-plugins",
+		"title": "Some plugins needs to be updated",
+		"source": "Wordpress",
+		"date": 1654800000
+	},
+	{
+		"severity": "success",
+		"icon": "ab-icon dashicons-megaphone",
+		"title": "Word Camp Europe 2022",
+		"message": "Word Camp was successfully updated to version 2022",
+		"source": "Wordpress",
+		"date": 1654800000
+	},
+	{
+		"image": "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y",
+		"message": "WordPress User has left a message on Lorem Ipsum.",
+		"source": "Comment",
+		"date": 1654400000
+	},
+	{
+		"image": "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y",
+		"message": "WordPress User has left a message on Lorem Ipsum.",
+		"source": "Comment",
+		"date": 1654000000
+	}
+]

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -59,6 +59,7 @@ require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/interfac
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/class-wp-notify-abstract-notification-repository.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/class-wp-notify-wpdb-notification-repository.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/demo.php';
+require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/class-notification-controller.php';
 
 // TODO: Standardise structure and/or autoloading.
 new REST\Notification_Controller();

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -14,6 +14,8 @@
  * @package wp-feature-notifications
  */
 
+use WP\Notifications\REST;
+
 if ( ! defined( 'WP_NOTIFICATION_CENTER_PLUGIN_VERSION' ) ) {
 	define( 'WP_NOTIFICATION_CENTER_PLUGIN_VERSION', '0.0.1' );
 }
@@ -57,3 +59,6 @@ require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/interfac
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/class-wp-notify-abstract-notification-repository.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/class-wp-notify-wpdb-notification-repository.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/demo.php';
+
+// TODO: Standardise structure and/or autoloading.
+new REST\Notification_Controller();

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -59,7 +59,7 @@ require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/interfac
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/class-wp-notify-abstract-notification-repository.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/persistence/class-wp-notify-wpdb-notification-repository.php';
 require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/demo.php';
-require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/class-notification-controller.php';
+require_once WP_NOTIFICATION_CENTER_PLUGIN_DIR . '/includes/restapi/class-notification-controller.php';
 
 // TODO: Standardise structure and/or autoloading.
 new REST\Notification_Controller();


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds a demo REST Controller for fetching notifications.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This allows us to move the demo content to the PHP side, allowing real js querying of the endpoint.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
