### PR TITLE
hides /src/stories/assets and package.json from linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # exclude vendored and generated files
-package.json linguist-generated
+package-lock.json linguist-generated
 /src/stories/assets/** linguist-vendored
 /docs/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# exclude vendored and generated files
+package.json linguist-generated=true
+/src/stories/assets/** linguist-vendored=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # exclude vendored and generated files
-package.json linguist-generated=true
-/src/stories/assets/** linguist-vendored=true
+package.json linguist-generated
+/src/stories/assets/** linguist-vendored
+/docs/** linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # exclude vendored and generated files
 package.json linguist-generated
 /src/stories/assets/** linguist-vendored
-/docs/** linguist-generated
+/docs/** linguist-documentation


### PR DESCRIPTION
## What?
Exclude vendored and generated files

## Why?
https://github.com/WordPress/wp-feature-notifications/issues/138

## How?
added to .gitattributes this content
```
# exclude vendored and generated files
package.json linguist-generated=true
/src/stories/assets/** linguist-vendored=true
```

close https://github.com/WordPress/wp-feature-notifications/issues/138