### PR TITLE
build: add jsconfig.json and @types/jest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
 	env: {
 		browser: true,
 		es2021: true,
+		jest: true,
 	},
 	extends: ['plugin:@wordpress/eslint-plugin/recommended'],
 };

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "types": ["jest"]
+  },
+  "include": ["**/*.js"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@storybook/manager-webpack5": "^6.5.15",
 				"@storybook/react": "^6.5.15",
 				"@storybook/testing-library": "^0.0.13",
+				"@types/jest": "^29.5.0",
 				"@wordpress/api-fetch": "^6.21.0",
 				"@wordpress/babel-preset-default": "^7.8.0",
 				"@wordpress/components": "^23.1.0",
@@ -3199,6 +3200,27 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@jest/expect-utils": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
+			"integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
+			"dev": true,
+			"dependencies": {
+				"jest-get-type": "^29.4.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils/node_modules/jest-get-type": {
+			"version": "29.4.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+			"integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/@jest/fake-timers": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.5.1.tgz",
@@ -3665,6 +3687,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "29.4.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+			"integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.25.16"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/source-map": {
@@ -4632,6 +4666,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
 			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+			"dev": true
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.25.24",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+			"integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
 			"dev": true
 		},
 		"node_modules/@sinonjs/commons": {
@@ -21026,6 +21066,245 @@
 			"dev": true,
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jest": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
+			"integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
+			"dev": true,
+			"dependencies": {
+				"expect": "^29.0.0",
+				"pretty-format": "^29.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/@jest/types": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
+			"integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.4.3",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/@types/yargs": {
+			"version": "17.0.23",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.23.tgz",
+			"integrity": "sha512-yuogunc04OnzGQCrfHx+Kk883Q4X0aSwmYZhKjI21m+SVYzjIbrWl8dOOwSv5hf2Um2pdCOXWo9isteZTNXUZQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/jest/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@types/jest/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@types/jest/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/@types/jest/node_modules/diff-sequences": {
+			"version": "29.4.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+			"integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/expect": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
+			"integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/expect-utils": "^29.5.0",
+				"jest-get-type": "^29.4.3",
+				"jest-matcher-utils": "^29.5.0",
+				"jest-message-util": "^29.5.0",
+				"jest-util": "^29.5.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-diff": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
+			"integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"diff-sequences": "^29.4.3",
+				"jest-get-type": "^29.4.3",
+				"pretty-format": "^29.5.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-get-type": {
+			"version": "29.4.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+			"integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-matcher-utils": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
+			"integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^29.5.0",
+				"jest-get-type": "^29.4.3",
+				"pretty-format": "^29.5.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-message-util": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
+			"integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.5.0",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.5.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-util": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
+			"integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.5.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/pretty-format": {
+			"version": "29.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+			"integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.4.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@types/jest/node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+			"dev": true
+		},
+		"node_modules/@types/jest/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"@storybook/manager-webpack5": "^6.5.15",
 		"@storybook/react": "^6.5.15",
 		"@storybook/testing-library": "^0.0.13",
+		"@types/jest": "^29.5.0",
 		"@wordpress/api-fetch": "^6.21.0",
 		"@wordpress/babel-preset-default": "^7.8.0",
 		"@wordpress/components": "^23.1.0",


### PR DESCRIPTION
This fixes Intellisense auto complete in tests, and fixes the `eslint` errors in the test files.

<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add `jsconfig.json` file and `@types/jest` as a dependency to improve IDE experience in tests. And fix `eslint` errors in tests of `describe` and `it` being `undefined`.
