### PR TITLE
Ci / Split tasks to avoid testing issues

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,18 @@
+name: Coding Standards
+
+on:
+  pull_request:
+    branches: [ develop, trunk ]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Check Coding Standards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: WPCS check
+        uses: 10up/wpcs-action@stable
+        with:
+          enable_warnings: true
+          use_local_config: true

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       - run: npm run build --if-present
 

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -8,11 +8,13 @@ on:
 jobs:
   build:
     name: Build plugin
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [16.x, 18.x]
+        os: [linux, macos, windows]
+
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -23,25 +25,3 @@ jobs:
       - run: npm install
       - run: npm run build --if-present
 
-
-  tests:
-    name: E2E testing
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup environment to use the desired version of NodeJS
-        uses: actions/setup-node@v3
-
-      - name: Installing NPM dependencies
-        run: npm install
-
-      - name: Installing wp-env
-        run: npm -g i @wordpress/env
-
-      - name: Starting the WordPress Environment
-        run: wp-env start
-
-      - name: Running the tests
-        run: npm run test

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version: [16.x, 18.x]
-        os: [linux, macos, windows]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -59,9 +59,6 @@ jobs:
     - name: Installing NPM dependencies
       run: npm ci
 
-    - name: Installing wp-env
-      run: npm -g i @wordpress/env
-
     - name: Install WordPress and initialize database
       run: ./tests/bin/install-wp-tests.sh wp_notify_tests root wordpress 127.0.0.1 latest
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0' ]
+        php: [ '7.2', '7.4', '8.0' ]
         wp: [ 'latest' ]
     services:
       database:
@@ -53,20 +53,23 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
 
+    - name: Setup environment to use the desired version of NodeJS
+      uses: actions/setup-node@v3
+
+    - name: Installing NPM dependencies
+      run: npm install
+
+    - name: Installing wp-env
+      run: npm -g i @wordpress/env
+
     - name: Install WordPress and initialize database
       run: ./tests/bin/install-wp-tests.sh wp_notify_tests root wordpress 127.0.0.1 latest
 
     - name: Run PHP Unit tests
       run: composer run test
 
-  lint:
-    name: Check Coding Standards
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: WPCS check
-        uses: 10up/wpcs-action@stable
-        with:
-          enable_warnings: true
-          use_local_config: true
+    - name: Starting the WordPress Environment
+      run: wp-env start
 
+    - name: Running the tests
+      run: npm run test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/setup-node@v3
 
     - name: Installing NPM dependencies
-      run: npm install
+      run: npm ci
 
     - name: Installing wp-env
       run: npm -g i @wordpress/env

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -69,7 +69,7 @@ jobs:
       run: composer run test
 
     - name: Starting the WordPress Environment
-      run: wp-env start
+      run: npm run wp-env:start
 
     - name: Running the tests
       run: npm run test


### PR DESCRIPTION
## What?
We update ci to separate build tasks with test tasks

## Why?
With the new setup we need composer to build the autoload.php file before testing, otherwise the autoloaded files are missing

## How?
Three files representing the three tasks were created, and in the testing one all the tests were merged
(bonus) added the os testing for node
removed -> php 7.3