### PR TITLE
build: add prepare script to install git hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"docGen": "npx docgen src/scripts/wp-notify.js",
 		"wp-env:start": "wp-env start",
 		"wp-env:stop": "wp-env stop",
-		"wp-env:destroy": "wp-env destroy"
+		"wp-env:destroy": "wp-env destroy",
+		"prepare": "husky install"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The husky precommit hook isn't automatically installed currently, and it should be.
