### PR TITLE
chore: add languages directory

### DIFF
--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -8,6 +8,7 @@
  * Requires PHP:      7.4
  * Author:            WP Feature Notifications Contributors
  * Text Domain:       wp-feature-notifications
+ * Domain Path:       /languages
  * License:           GPL v2 or later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  *


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add the `languages` directory in preparation for generating a POT file.

## Why?

Starts work on #209.

## How?

Adds `Domain Path: /languages` to  the plugin header, and creates the directory.