### PR TITLE
fix: previous files interpolation in .lintstagedrc

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
-	"**/*.(json|yml|yaml)": "prettier --write ${files}",
+	"**/*.(json|yml|yaml)": "prettier --write",
 	"**/*.(js|jsx|cjs|mjs|ts|tsx)": "eslint --ext .js,.jsx,.cjs,.mjs,.ts,.tsx --fix",
 	"**/*.php": "php vendor/bin/phpcbf --standard=phpcs.xml.dist -s --report=summary"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

fix: previous files variable interpolation in .lintstagedrc

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

The lint-staged config for prettier is broken.