### PR TITLE
fix(js): notices loop item key

### DIFF
--- a/src/scripts/components/NoticesLoop.js
+++ b/src/scripts/components/NoticesLoop.js
@@ -10,4 +10,4 @@ import { Notice } from './Notice';
  * @return {Array} An array of Notice components.
  */
 export const NoticesLoop = ( { notices } ) =>
-	notices.map( ( notify, index ) => <Notice { ...notify } key={ index } /> );
+	notices.map( ( notify ) => <Notice { ...notify } key={ notify.id } /> );


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Use the notice's id as the component key rather than the array index.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

React uses the key to determine how to update the DOM, if the index is used as a key, and an item is removed from the middle of the array. React doesn't know about it and removes the last element in the list and leaves the element that was intended for removal in the DOM.
