### PR TITLE
build: add typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
 				"jest-puppeteer": "^6.2.0",
 				"lint-staged": "^13.2.0",
 				"moment": "^2.29.3",
-				"prettier": "npm:wp-prettier@^2.8.5"
+				"prettier": "npm:wp-prettier@^2.8.5",
+				"typescript": "^5.0.3"
 			},
 			"engines": {
 				"node": ">=14",
@@ -17220,7 +17221,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
 			"integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
 		"jest-puppeteer": "^6.2.0",
 		"lint-staged": "^13.2.0",
 		"moment": "^2.29.3",
-		"prettier": "npm:wp-prettier@^2.8.5"
+		"prettier": "npm:wp-prettier@^2.8.5",
+		"typescript": "^5.0.3"
 	},
 	"dependencies": {
 		"dompurify": "^2.4.0"


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add `typescript` to enable JSDoc typing of the JavaScript code base. The `@wordpress/eslint-plugin` docs state that adding `typescript` will enable the proper ESLint configuration for importing JSDoc types between files.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Proper typing greatly enhances IDE autocomplete and API discovery .

Typing will also help catch errors.
