### PR TITLE
build: configure ESLint for JSDoc types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,10 +2,26 @@
  * ESLint presets
  */
 module.exports = {
+	root: true,
+	parser: '@typescript-eslint/parser',
+	parserOptions: {
+		project: [ './jsconfig.json', 'jsconfig.eslint.json' ],
+	},
+	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	settings: {
+		'import/parsers': {
+			'@typescript-eslint/parser': [ '.js', '.jsx', '.ts', '.tsx' ],
+		},
+		'import/resolver': {
+			typescript: {
+				alwaysTryTypes: true,
+				project: [ './jsconfig.json', 'jsconfig.eslint.json' ],
+			},
+		},
+	},
 	env: {
 		browser: true,
 		es2021: true,
 		jest: true,
 	},
-	extends: ['plugin:@wordpress/eslint-plugin/recommended'],
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,3 @@
 // Import the default config file and expose it in the project root.
 // Useful for editor integrations.
-module.exports = require('@wordpress/prettier-config');
+module.exports = require( '@wordpress/prettier-config' );

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
-module.exports = (api) => {
-	api.cache(true);
+module.exports = ( api ) => {
+	api.cache( true );
 
 	return {
-		presets: ['@wordpress/babel-preset-default'],
+		presets: [ '@wordpress/babel-preset-default' ],
 	};
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,16 @@
 const jestConfig = {
 	verbose: true,
 	preset: '@wordpress/jest-preset-default',
-	setupFilesAfterEnv: ['expect-puppeteer'],
+	setupFilesAfterEnv: [ 'expect-puppeteer' ],
 	projects: [
 		{
 			displayName: 'unit',
-			testMatch: ['<rootDir>/tests/jsunit/**/*.test.js'],
+			testMatch: [ '<rootDir>/tests/jsunit/**/*.test.js' ],
 		},
 		{
 			displayName: 'e2e',
 			preset: 'jest-puppeteer',
-			testMatch: ['<rootDir>/tests/jse2e/**/*.test.js'],
+			testMatch: [ '<rootDir>/tests/jse2e/**/*.test.js' ],
 		},
 	],
 };

--- a/jsconfig.eslint.json
+++ b/jsconfig.eslint.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"noEmit": true,
+		"allowJs": true
+	},
+	"include": [
+		".eslintrc.js",
+		".prettierrc.js",
+		"babel.config.js",
+		"jest.config.js",
+		"webpack.config.js"
+	]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,9 @@
 {
-  "compilerOptions": {
-    "checkJs": true,
-    "types": ["jest"]
-  },
-  "include": ["**/*.js"]
+	"compilerOptions": {
+		"checkJs": true,
+		"types": [ "jest" ],
+		"baseUrl": "./src"
+	},
+	"include": [ "./src/**/*.js", "./src/**/*.jsx" ],
+	"exclude": [ "./node_modules" ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@wordpress/icons": "^9.21.0",
 				"@wordpress/scripts": "^26.1.0",
 				"classnames": "^2.3.2",
+				"eslint-import-resolver-typescript": "^3.5.5",
 				"husky": "^8.0.3",
 				"jest-puppeteer": "^6.2.0",
 				"lint-staged": "^13.2.0",
@@ -2647,6 +2648,76 @@
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@pkgr/utils": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.1.tgz",
+			"integrity": "sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"is-glob": "^4.0.3",
+				"open": "^8.4.0",
+				"picocolors": "^1.0.0",
+				"tiny-glob": "^0.2.9",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
 			},
 			"engines": {
 				"node": ">= 8"
@@ -7944,6 +8015,63 @@
 				"ms": "^2.1.1"
 			}
 		},
+		"node_modules/eslint-import-resolver-typescript": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.5.tgz",
+			"integrity": "sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4",
+				"enhanced-resolve": "^5.12.0",
+				"eslint-module-utils": "^2.7.4",
+				"get-tsconfig": "^4.5.0",
+				"globby": "^13.1.3",
+				"is-core-module": "^2.11.0",
+				"is-glob": "^4.0.3",
+				"synckit": "^0.8.5"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+			},
+			"peerDependencies": {
+				"eslint": "*",
+				"eslint-plugin-import": "*"
+			}
+		},
+		"node_modules/eslint-import-resolver-typescript/node_modules/globby": {
+			"version": "13.1.3",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+			"integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+			"dev": true,
+			"dependencies": {
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.11",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-import-resolver-typescript/node_modules/slash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/eslint-module-utils": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
@@ -9282,6 +9410,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-tsconfig": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.5.0.tgz",
+			"integrity": "sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
 		"node_modules/gettext-parser": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
@@ -9382,6 +9519,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/globalyzer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+			"dev": true
+		},
 		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -9406,6 +9549,12 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
 			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+			"dev": true
+		},
+		"node_modules/globrex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
 			"dev": true
 		},
 		"node_modules/good-listener": {
@@ -16677,6 +16826,22 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
+		"node_modules/synckit": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+			"integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+			"dev": true,
+			"dependencies": {
+				"@pkgr/utils": "^2.3.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
 		"node_modules/table": {
 			"version": "6.8.1",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -16960,6 +17125,16 @@
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
 			"dev": true
+		},
+		"node_modules/tiny-glob": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+			"dev": true,
+			"dependencies": {
+				"globalyzer": "0.1.0",
+				"globrex": "^0.1.2"
+			}
 		},
 		"node_modules/tmp": {
 			"version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"@wordpress/icons": "^9.21.0",
 		"@wordpress/scripts": "^26.1.0",
 		"classnames": "^2.3.2",
+		"eslint-import-resolver-typescript": "^3.5.5",
 		"husky": "^8.0.3",
 		"jest-puppeteer": "^6.2.0",
 		"lint-staged": "^13.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
-const path = require('path');
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const path = require( 'path' );
 
 module.exports = {
 	...defaultConfig,
-	entry: { 'wp-notify': path.resolve(process.cwd(), `src/wp-notify.js`) },
+	entry: { 'wp-notify': path.resolve( process.cwd(), `src/wp-notify.js` ) },
 };


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

ESLint configuration requires some tweaks to work well with JSDoc types.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Without this changes there are linting errors when importing JSDoc types from other files.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add the TypeScript import resolver and configure properly.

Details of why `jsconfig.eslint.json` is also necessary can be found here https://typescript-eslint.io/linting/troubleshooting/#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file