### PR TITLE
feature: add channel registry

### DIFF
--- a/includes/channels.php
+++ b/includes/channels.php
@@ -8,14 +8,18 @@
 namespace WP\Notifications;
 
 /**
- * Register a channel.
+ * Register a notification channel.
  *
- * @param Channel $channel A complete Channel instance.
- *
+ * @param string|Channel $name  Channel name including namespace, or alternatively a complete
+ *                              Channel instance. In case a Channel is provided, the $args
+ *                              parameter will be ignored.
+ * @param array          $args  Optional. Array of channel arguments. Accepts any public property
+ *                              of `Channel`. See Channel::__construct() for information on
+ *                              accepted arguments. Default empty array.
  * @return Channel|false The registered channel on success, or false on failure.
  */
-function register_channel( $channel ) {
-	return Channel_Registry::get_instance()->register( $channel );
+function register_channel( $name, $args = array() ) {
+	return Channel_Registry::get_instance()->register( $name, $args );
 }
 
 /**

--- a/includes/channels.php
+++ b/includes/channels.php
@@ -21,12 +21,10 @@ function register_channel( $channel ) {
 /**
  * Unregister a channel.
  *
- * @since 5.0.0
- *
  * @param string|Channel $name Channel name including namespace, or alternatively a complete
  *                             Channel instance.
  * @return Channel|false The unregistered channel on success, or false on failure.
  */
-function unregister_block_type( $name ) {
+function unregister_channel( $name ) {
 	return Channel_Registry::get_instance()->unregister( $name );
 }

--- a/includes/channels.php
+++ b/includes/channels.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Functions related to registering channels.
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+/**
+ * Register a channel.
+ *
+ * @param Channel $channel A complete Channel instance.
+ *
+ * @return Channel|false The registered channel on success, or false on failure.
+ */
+function register_channel( $channel ) {
+	return Channel_Registry::get_instance()->register( $channel );
+}
+
+/**
+ * Unregister a channel.
+ *
+ * @since 5.0.0
+ *
+ * @param string|Channel $name Channel name including namespace, or alternatively a complete
+ *                             Channel instance.
+ * @return Channel|false The unregistered channel on success, or false on failure.
+ */
+function unregister_block_type( $name ) {
+	return Channel_Registry::get_instance()->unregister( $name );
+}

--- a/includes/channels.php
+++ b/includes/channels.php
@@ -28,3 +28,120 @@ function register_channel( $channel ) {
 function unregister_channel( $name ) {
 	return Channel_Registry::get_instance()->unregister( $name );
 }
+
+// Register core notification channels.
+
+add_action(
+	'init',
+	function () {
+		register_channel(
+			new Channel(
+				'core/updates',
+				array(
+					'title'       => __( 'WordPress Updates', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'WordPress core update events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-install',
+				array(
+					'title'       => __( 'Plugin Install', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin install events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-uninstall',
+				array(
+					'title'       => __( 'Plugin Uninstall', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin uninstall events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-activate',
+				array(
+					'title'       => __( 'Plugin Activate', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin activation events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-deactivate',
+				array(
+					'title'       => __( 'Plugin Deactivate', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin deactivation events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-updates',
+				array(
+					'title'       => __( 'Plugin Update', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin update events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/post-new',
+				array(
+					'title'       => __( 'New Post', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Post creation events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/post-edit',
+				array(
+					'title'       => __( 'Edit Post', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Post edit events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/post-delete',
+				array(
+					'title'       => __( 'Delete Post', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Post delete events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/comment-new',
+				array(
+					'title'       => __( 'New Comment', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Comment creation events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+	}
+);

--- a/includes/class-channel-registery.php
+++ b/includes/class-channel-registery.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Notifications API:Channel_Registry class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+/**
+ * Class used for interacting with channels.
+ */
+final class Channel_Registry {
+
+	/**
+	 * Registered channels, as `$name => $instance` pairs.
+	 *
+	 * @var Channel
+	 */
+	private $registered_channels = array();
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @var Channel_Registry|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Registers a channel.
+	 *
+	 * @param Channel $name A Channel instance.
+   *
+	 * @return Channel|false The registered channel on success, or false on failure.
+	 */
+	public function register( $name ) {
+		$channel = null;
+		if ( $name instanceof Channel ) {
+			$channel = $name;
+			$name    = $channel->get_name();
+		}
+	}
+
+	/**
+	 * Unregister a channel.
+	 *
+	 * @param string|Channel $name Channel type name including namespace, or alternatively a complete
+	 *                             Channel instance.
+	 * @return Channel|false The unregistered channel on success, or false on failure.
+	 */
+	public function unregister( $name ) {
+		if ( $name instanceof Channel ) {
+			$name = $name->get_name();
+		}
+
+		if ( ! $this->is_registered( $name ) ) {
+			return false;
+		}
+
+		$unregistered_channel = $this->registered_channels[ $name ];
+		unset( $this->registered_channels[ $name ] );
+
+		return $unregistered_channel;
+	}
+
+	/**
+	 * Retrieves a registered channel.
+	 *
+	 * @param string $name Channel name including namespace.
+	 *
+	 * @return Channel|null The registered channel, or null if it is not registered.
+	 */
+	public function get_registered( $name ) {
+		if ( ! $this->is_registered( $name ) ) {
+			return null;
+		}
+
+		return $this->registered_channels[ $name ];
+	}
+
+	/**
+	 * Retrieves all registered channels.
+	 *
+	 * @return Channel[] Associative array of `$channel_name => $channel` pairs.
+	 */
+	public function get_all_registered() {
+		return $this->registered_channels;
+	}
+
+	/**
+	 * Checks if a channel is registered.
+	 *
+	 * @param string $name Chanel name including namespace.
+   *
+	 * @return bool True if the channel is registered, false otherwise.
+	 */
+	public function is_registered( $name ) {
+		return isset( $this->registered_channels[ $name ] );
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @return Channel_Registry The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+}

--- a/includes/class-channel-registery.php
+++ b/includes/class-channel-registery.php
@@ -37,7 +37,7 @@ final class Channel_Registry {
 		$channel = null;
 		if ( $name instanceof Channel ) {
 			$channel = $name;
-			$name    = $channel->get_name();
+			$name    = $channel->name;
 		}
 	}
 
@@ -50,7 +50,7 @@ final class Channel_Registry {
 	 */
 	public function unregister( $name ) {
 		if ( $name instanceof Channel ) {
-			$name = $name->get_name();
+			$name = $name->name;
 		}
 
 		if ( ! $this->is_registered( $name ) ) {

--- a/includes/class-channel-registry.php
+++ b/includes/class-channel-registry.php
@@ -29,16 +29,18 @@ final class Channel_Registry {
 	/**
 	 * Registers a channel.
 	 *
-	 * @param Channel $name A Channel instance.
+	 * @param Channel $channel A Channel instance.
 	 *
 	 * @return Channel|false The registered channel on success, or false on failure.
 	 */
-	public function register( $name ) {
-		$channel = null;
-		if ( $name instanceof Channel ) {
-			$channel = $name;
-			$name    = $channel->name;
+	public function register( $channel ) {
+		if ( ! ( $channel instanceof Channel ) ) {
+			return false;
 		}
+
+		$this->registered_channels[ $channel->name ] = $channel;
+
+		return $channel;
 	}
 
 	/**

--- a/includes/class-channel-registry.php
+++ b/includes/class-channel-registry.php
@@ -15,7 +15,7 @@ final class Channel_Registry {
 	/**
 	 * Registered channels, as `$name => $instance` pairs.
 	 *
-	 * @var Channel
+	 * @var Channel[]
 	 */
 	private $registered_channels = array();
 

--- a/includes/class-channel-registry.php
+++ b/includes/class-channel-registry.php
@@ -30,7 +30,7 @@ final class Channel_Registry {
 	 * Registers a channel.
 	 *
 	 * @param Channel $name A Channel instance.
-   *
+	 *
 	 * @return Channel|false The registered channel on success, or false on failure.
 	 */
 	public function register( $name ) {
@@ -91,7 +91,7 @@ final class Channel_Registry {
 	 * Checks if a channel is registered.
 	 *
 	 * @param string $name Chanel name including namespace.
-   *
+	 *
 	 * @return bool True if the channel is registered, false otherwise.
 	 */
 	public function is_registered( $name ) {

--- a/includes/class-channel-registry.php
+++ b/includes/class-channel-registry.php
@@ -29,7 +29,7 @@ final class Channel_Registry {
 	/**
 	 * Registers a channel.
 	 *
-	 * @see Channel::__construct()
+	 * @see \WP\Notifications\Channel::__construct()
 	 *
 	 * @param string|Channel $name  Channel name including namespace, or alternatively a complete
 	 *                              Channel instance. In case a Channel is provided, the $args

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -49,7 +49,7 @@ class Channel implements JsonSerializable {
 	 *
 	 * Instantiates a Channel object.
 	 *
-	 * @see wp_feature_notifications_register_channel()
+	 * @see WP\Notifications\register_channel()
 	 *
 	 * @param string       $channel Channel name including namespace.
 	 * @param array|string $args    {

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -12,7 +12,7 @@ use JsonSerializable;
 /**
  * Class representing a channel.
  *
- * @see \WP\Notifications\register_channel()
+ * @see register_channel()
  */
 class Channel implements JsonSerializable {
 	/**
@@ -20,14 +20,14 @@ class Channel implements JsonSerializable {
 	 *
 	 * @var string
 	 */
-	public $name;
+	public string $name;
 
 	/**
 	 * Human-readable channel label.
 	 *
 	 * @var string
 	 */
-	public $title = '';
+	public string $title = '';
 
 	/**
 	 * Channel icon.
@@ -49,7 +49,7 @@ class Channel implements JsonSerializable {
 	 *
 	 * Instantiates a Channel object.
 	 *
-	 * @see \WP\Notifications\register_channel()
+	 * @see register_channel()
 	 *
 	 * @param string       $channel Channel name including namespace.
 	 * @param array|string $args    {
@@ -61,11 +61,13 @@ class Channel implements JsonSerializable {
 	 *     @type string|null $description Optional detailed channel description.
 	 * }
 	 */
-	public function __construct( $channel, $args ) {
+	public function __construct( string $channel, $args ) {
+		$parsed = wp_parse_args( $args );
+
 		$this->name        = $channel;
-		$this->title       = $args['title'];
-		$this->icon        = array_key_exists( 'icon', $args ) ? $args['icon'] : null;
-		$this->description = array_key_exists( 'description', $args ) ? $args['description'] : null;
+		$this->title       = $parsed['title'];
+		$this->icon        = array_key_exists( 'icon', $parsed ) ? $parsed['icon'] : null;
+		$this->description = array_key_exists( 'description', $parsed ) ? $parsed['description'] : null;
 	}
 
 	/**

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -52,15 +52,20 @@ class Channel implements JsonSerializable {
 	 * @see wp_feature_notifications_register_channel()
 	 *
 	 * @param string      $channel     Channel name including namespace.
-	 * @param string      $title       Human-readable channel label.
-	 * @param string|null $icon        Channel icon.
-	 * @param string|null $description A detailed channel description.
+	 * @param array|string $args       {
+	 *     Array or string of arguments for registering a channel. Supported arguments are
+	 *     described below.
+	 *
+	 *     @type string        $title                    Human-readable channel label.
+	 *     @type string|null   $icon      Channel icon.
+	 *     @type string|null   $description A detailed channel description.
+	 * }
 	 */
-	public function __construct( $channel, $title, $icon = null, $description = null ) {
+	public function __construct( $channel, $args ) {
 		$this->name        = $channel;
-		$this->title       = $title;
-		$this->icon        = $icon;
-		$this->description = $description;
+		$this->title       = $args['title'];
+		$this->icon        = $args['icon'];
+		$this->description = $args['description'];
 	}
 
 	/**

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -51,21 +51,21 @@ class Channel implements JsonSerializable {
 	 *
 	 * @see wp_feature_notifications_register_channel()
 	 *
-	 * @param string      $channel     Channel name including namespace.
-	 * @param array|string $args       {
+	 * @param string       $channel Channel name including namespace.
+	 * @param array|string $args    {
 	 *     Array or string of arguments for registering a channel. Supported arguments are
 	 *     described below.
 	 *
-	 *     @type string        $title                    Human-readable channel label.
-	 *     @type string|null   $icon      Channel icon.
-	 *     @type string|null   $description A detailed channel description.
+	 *     @type string      $title       Human-readable channel label.
+	 *     @type string|null $icon        Optional channel icon.
+	 *     @type string|null $description Optional detailed channel description.
 	 * }
 	 */
 	public function __construct( $channel, $args ) {
 		$this->name        = $channel;
 		$this->title       = $args['title'];
-		$this->icon        = $args['icon'];
-		$this->description = $args['description'];
+		$this->icon        = array_key_exists( 'icon', $args ) ? $args['icon'] : null;
+		$this->description = array_key_exists( 'description', $args ) ? $args['description'] : null;
 	}
 
 	/**

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -12,7 +12,7 @@ use JsonSerializable;
 /**
  * Class representing a channel.
  *
- * @see register_channel()
+ * @see \WP\Notifications\register_channel()
  */
 class Channel implements JsonSerializable {
 	/**
@@ -49,7 +49,7 @@ class Channel implements JsonSerializable {
 	 *
 	 * Instantiates a Channel object.
 	 *
-	 * @see WP\Notifications\register_channel()
+	 * @see \WP\Notifications\register_channel()
 	 *
 	 * @param string       $channel Channel name including namespace.
 	 * @param array|string $args    {

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Notifications API:Channel class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+use JsonSerializable;
+
+/**
+ * Class representing a channel.
+ *
+ * @see wp_feature_notifications_register_channel()
+ */
+class Channel implements JsonSerializable {
+	/**
+	 * Channel key.
+	 *
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * Human-readable channel label.
+	 *
+	 * @var string
+	 */
+	protected $title = '';
+
+	/**
+	 * Channel icon.
+	 *
+	 * @var string|null
+	 */
+	protected $icon = null;
+
+
+	/**
+	 * Channel description.
+	 *
+	 * @var string|null
+	 */
+	protected $description = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * Instantiates a Channel object.
+	 *
+	 * @see wp_feature_notifications_register_channel()
+	 *
+	 * @param string      $channel     Channel name including namespace.
+	 * @param string      $title       Human-readable channel label.
+	 * @param string|null $icon        Channel icon.
+	 * @param string|null $description A detailed channel description.
+	 */
+	public function __construct( $channel, $title, $icon = null, $description = null ) {
+		$this->name        = $channel;
+		$this->title       = $title;
+		$this->icon        = $icon;
+		$this->description = $description;
+	}
+
+	/**
+   * Get the name of the channel.
+   *
+   * @return string Name of the channel.
+   */
+	public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * Get the title of the channel.
+	 *
+	 * @return string Title of the channel.
+	 */
+	public function get_title() {
+		return $this->title;
+	}
+
+	/**
+	 * Get the icon of the channel.
+	 *
+	 * @return string|null Icon of the channel.
+	 */
+	public function get_icon() {
+		return $this->icon;
+	}
+
+	/**
+	 * Get the icon of the description.
+	 *
+	 * @return string|null Description of the channel.
+	 */
+	public function get_description() {
+		return $this->description;
+	}
+
+	/**
+	 * Specifies data which should be serialized to JSON.
+	 *
+	 * @return mixed Data which can be serialized by json_encode, which is a
+	 *               value of any type other than a resource.
+	 */
+	public function jsonSerialize(): mixed {
+		return array(
+			'name'        => $this->name,
+			'title'       => $this->title,
+			'icon'        => $this->icon,
+			'description' => $this->description,
+		);
+	}
+}

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -12,7 +12,7 @@ use JsonSerializable;
 /**
  * Class representing a channel.
  *
- * @see wp_feature_notifications_register_channel()
+ * @see register_channel()
  */
 class Channel implements JsonSerializable {
 	/**

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -20,21 +20,21 @@ class Channel implements JsonSerializable {
 	 *
 	 * @var string
 	 */
-	protected $name;
+	public $name;
 
 	/**
 	 * Human-readable channel label.
 	 *
 	 * @var string
 	 */
-	protected $title = '';
+	public $title = '';
 
 	/**
 	 * Channel icon.
 	 *
 	 * @var string|null
 	 */
-	protected $icon = null;
+	public $icon = null;
 
 
 	/**
@@ -42,7 +42,7 @@ class Channel implements JsonSerializable {
 	 *
 	 * @var string|null
 	 */
-	protected $description = null;
+	public $description = null;
 
 	/**
 	 * Constructor.
@@ -61,42 +61,6 @@ class Channel implements JsonSerializable {
 		$this->title       = $title;
 		$this->icon        = $icon;
 		$this->description = $description;
-	}
-
-	/**
-   * Get the name of the channel.
-   *
-   * @return string Name of the channel.
-   */
-	public function get_name() {
-		return $this->name;
-	}
-
-	/**
-	 * Get the title of the channel.
-	 *
-	 * @return string Title of the channel.
-	 */
-	public function get_title() {
-		return $this->title;
-	}
-
-	/**
-	 * Get the icon of the channel.
-	 *
-	 * @return string|null Icon of the channel.
-	 */
-	public function get_icon() {
-		return $this->icon;
-	}
-
-	/**
-	 * Get the icon of the description.
-	 *
-	 * @return string|null Description of the channel.
-	 */
-	public function get_description() {
-		return $this->description;
 	}
 
 	/**

--- a/includes/class-message.php
+++ b/includes/class-message.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Notifications API:Message class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+use JsonSerializable;
+
+/**
+ * Class representing a message.
+ */
+class Message implements JsonSerializable {
+
+	/**
+	 * Message title.
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * Message content.
+	 *
+	 * @var string
+	 */
+	public $content = '';
+
+	/**
+	 * Message icon.
+	 *
+	 * @var string|null
+	 */
+	public $icon = null;
+
+	/**
+	 * Message context.
+	 *
+	 * @var string
+	 */
+	public $context = null;
+
+	/**
+	 * Message content.
+	 *
+	 * @var string
+	 */
+	public $severity = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * Instantiates a Message object.
+	 *
+	 * @param string      $title    Message title.
+	 * @param string      $content  Message content.
+	 * @param string|null $icon     Message icon.
+	 * @param string|null $context  Message context.
+	 * @param string|null $severity Message severity.
+	 */
+	public function __construct( $title, $content, $icon = null, $context = null, $severity = null ) {
+		$this->title    = $title;
+		$this->content  = $content;
+		$this->icon     = $icon;
+		$this->context  = $context;
+		$this->severity = $severity;
+	}
+
+	/**
+	 * Specifies data which should be serialized to JSON.
+	 *
+	 * @return mixed Data which can be serialized by json_encode, which is a
+	 *               value of any type other than a resource.
+	 */
+	public function jsonSerialize(): mixed {
+		return array(
+			'title'    => $this->title,
+			'content'  => $this->content,
+			'icon'     => $this->icon,
+			'context'  => $this->context,
+			'severity' => $this->severity,
+		);
+	}
+}

--- a/tests/phpunit/tests/test-channel-registry.php
+++ b/tests/phpunit/tests/test-channel-registry.php
@@ -2,26 +2,147 @@
 
 namespace WP\Notifications\Test;
 
-use WP_Notify_TestCase;
+use WP_UnitTestCase;
 use WP\Notifications;
 
-use function WP\Notifications\register_channel;
+class Test_Channel_Registry extends WP_UnitTestCase {
+	/**
+	   * Fake channel registry.
+	   *
+	   * @var Channel_Registry
+	   */
+	private $registry = null;
 
-class Test_Channel_Registry extends WP_Notify_TestCase {
-	public function test_it_should_add_channel_to_registry() {
-		$expected = new Notifications\Channel(
-			'core/test',
-			array(
-				'title'       => 'Testing',
-				'icon'        => 'wordpress',
-				'description' => 'Test notification channel.',
-			)
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->registry = new Notifications\Channel_Registry();
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->registry = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	   * Should reject channel without a namespace.
+	   *
+	   * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	   */
+	public function test_invalid_names_without_namespace() {
+		$result = $this->registry->register( 'test', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	   * Should reject channels with invalid characters.
+	   *
+	   * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	   */
+	public function test_invalid_characters() {
+		$result = $this->registry->register( 'test/_doing_it_wrong', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should reject channels with uppercase characters.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	 */
+	public function test_uppercase_characters() {
+		$result = $this->registry->register( 'Core/Test', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should accept valid channel names
+	 */
+	public function test_register_channel() {
+		$name     = 'core/test';
+		$settings = array(
+			'title' => 'Test Channel',
 		);
 
-		register_channel( $expected );
+		$channel = $this->registry->register( $name, $settings );
+		$this->assertSame( $name, $channel->name );
+		$this->assertSame( $settings['description'], $channel->description );
+		$this->assertSame( $channel, $this->registry->get_registered( $name ) );
+	}
 
-		$actual = Notifications\Channel_Registry::get_instance()->get_registered( 'core/test' );
+	/**
+	 * Should fail to re-register the same channel.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	 */
+	public function test_register_channel_twice() {
+		$name     = 'core/test';
+		$settings = array(
+			'title' => 'Test Channel',
+		);
 
-		$this->assertSame( $expected, $actual );
+		$result = $this->registry->register( $name, $settings );
+		$this->assertNotFalse( $result );
+		$result = $this->registry->register( $name, $settings );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should accept a Channel instance.
+	 */
+	public function test_register_channel_instance() {
+		$channel = new Notifications\Channel( 'core/test', array( 'title' => 'Test Channel' ) );
+
+		$result = $this->registry->register( $channel );
+		$this->assertSame( $channel, $result );
+	}
+
+	/**
+	 * Unregistering should fail if a channel is not registered.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::unregister
+	 */
+	public function test_unregister_not_registered_channel() {
+		$result = $this->registry->unregister( 'core/unregistered' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should unregister existing channels.
+	 */
+	public function test_unregister_channel() {
+		$name     = 'core/test';
+		$settings = array(
+			'title' => 'Test Channel',
+		);
+
+		$this->registry->register( $name, $settings );
+		$channel = $this->registry->unregister( $name );
+		$this->assertSame( $name, $channel->name );
+		$this->assertSame( $settings['icon'], $channel->icon );
+		$this->assertFalse( $this->registry->is_registered( $name ) );
+	}
+
+	/**
+	 * Should return all registered channels.
+	 */
+	public function test_get_all_registered() {
+		$names    = array( 'core/updates', 'core/post-edit', 'core/post-delete' );
+		$settings = array(
+			'title' => 'random',
+		);
+
+		foreach ( $names as $name ) {
+			$this->registry->register( $name, $settings );
+		}
+
+		$registered = $this->registry->get_all_registered();
+		$this->assertSameSets( $names, array_keys( $registered ) );
 	}
 }

--- a/tests/phpunit/tests/test-channel-registry.php
+++ b/tests/phpunit/tests/test-channel-registry.php
@@ -7,10 +7,10 @@ use WP\Notifications;
 
 class Test_Channel_Registry extends WP_UnitTestCase {
 	/**
-	   * Fake channel registry.
-	   *
-	   * @var Channel_Registry
-	   */
+	 * Fake channel registry.
+	 *
+	 * @var Channel_Registry
+	 */
 	private $registry = null;
 
 	/**
@@ -32,20 +32,20 @@ class Test_Channel_Registry extends WP_UnitTestCase {
 	}
 
 	/**
-	   * Should reject channel without a namespace.
-	   *
-	   * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
-	   */
+	 * Should reject channel without a namespace.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	 */
 	public function test_invalid_names_without_namespace() {
 		$result = $this->registry->register( 'test', array() );
 		$this->assertFalse( $result );
 	}
 
 	/**
-	   * Should reject channels with invalid characters.
-	   *
-	   * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
-	   */
+	 * Should reject channels with invalid characters.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	 */
 	public function test_invalid_characters() {
 		$result = $this->registry->register( 'test/_doing_it_wrong', array() );
 		$this->assertFalse( $result );
@@ -72,7 +72,7 @@ class Test_Channel_Registry extends WP_UnitTestCase {
 
 		$channel = $this->registry->register( $name, $settings );
 		$this->assertSame( $name, $channel->name );
-		$this->assertSame( $settings['description'], $channel->description );
+		$this->assertSame( $settings['title'], $channel->title );
 		$this->assertSame( $channel, $this->registry->get_registered( $name ) );
 	}
 
@@ -125,7 +125,7 @@ class Test_Channel_Registry extends WP_UnitTestCase {
 		$this->registry->register( $name, $settings );
 		$channel = $this->registry->unregister( $name );
 		$this->assertSame( $name, $channel->name );
-		$this->assertSame( $settings['icon'], $channel->icon );
+		$this->assertSame( $settings['title'], $channel->title );
 		$this->assertFalse( $this->registry->is_registered( $name ) );
 	}
 

--- a/tests/phpunit/tests/test-channel-registry.php
+++ b/tests/phpunit/tests/test-channel-registry.php
@@ -12,7 +12,9 @@ class Test_Channel_Registry extends WP_Notify_TestCase {
 		$expected = new Notifications\Channel(
 			'core/test',
 			array(
-				'title' => 'Test Channel',
+				'title'       => 'Testing',
+				'icon'        => 'wordpress',
+				'description' => 'Test notification channel.',
 			)
 		);
 

--- a/tests/phpunit/tests/test-channel-registry.php
+++ b/tests/phpunit/tests/test-channel-registry.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP\Notifications\Test;
+
+use WP_Notify_TestCase;
+use WP\Notifications;
+
+use function WP\Notifications\register_channel;
+
+class Test_Channel_Registry extends WP_Notify_TestCase {
+	public function test_it_should_add_channel_to_registry() {
+		$expected = new Notifications\Channel(
+			'core/test',
+			array(
+				'title' => 'Test Channel',
+			)
+		);
+
+		register_channel( $expected );
+
+		$actual = Notifications\Channel_Registry::get_instance()->get_registered( 'core/test' );
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -19,6 +19,8 @@ namespace WP\Notifications;
 
 use WP\Notifications\REST;
 
+use function WP\Notifications\register_channel;
+
 if ( ! defined( 'WP_FEATURE_NOTIFICATION_PLUGIN_VERSION' ) ) {
 	define( 'WP_FEATURE_NOTIFICATION_PLUGIN_VERSION', '0.0.1' );
 }
@@ -32,6 +34,9 @@ if ( ! defined( 'WP_FEATURE_NOTIFICATION_PLUGIN_DIR_URL' ) ) {
 }
 
 // Require interface/class declarations..
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-channel.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-channel-registry.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/channels.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/interface-exception.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/class-runtime-exception.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/class-invalid-recipient.php';

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -19,8 +19,6 @@ namespace WP\Notifications;
 
 use WP\Notifications\REST;
 
-use function WP\Notifications\register_channel;
-
 if ( ! defined( 'WP_FEATURE_NOTIFICATION_PLUGIN_VERSION' ) ) {
 	define( 'WP_FEATURE_NOTIFICATION_PLUGIN_VERSION', '0.0.1' );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a `Channel_Registry` class to register notification channels.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

To attempt registering channels in code.

Implementing the data model of PR #168 has the challenge of when and how to look up plugin registered channels. If channel data is stored in a database table and an integer `id` column is used to link a channel to subscription and messages, how does a plugin know the `id` of the channel it registered? This data would have to be looked up on message emit, and also there wouldn't be a good mechanism to prevent plugins from registering similarly named channels.

Using a registry similar block types might work well. The channel is registered in code and the channel name/key/slug (as in `core/post-edit`) would link a message source to its channel. Subscriptions could also use the same key to link users to channels. This would also allow checking for conflicts at channel registration.

Keeping in mind that if/when a plugin is uninstalled, a message has to contain all the data required to render, it is necessary to store channel key and title in the message.

Both systems have pros and cons. This strategy removes the need for a channel table, and simplifies the logic of emitting a message. Though it will result in duplication of data in the database.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- `Channel_Registry` class, heavy based on core `Block_Type_Registry`
- `Channel` class
- `register_channel` function

## Further considerations

- When/if a plugin is uninstalled its channel subscriptions would remain in the database subscriptions table. Though this is a very small table compared with the queue table. And remembering user preferences is probably normal behavior, so there is a seamless experience if a plugin is reinstalled.
- The channel `icon` could be stored in the message's `icon` column if/when a message doesn't specify it's own.
