### PR TITLE
ci: remove php 7.2 add 8.1 and 8.2

### DIFF
--- a/.github/actions/php/action.yml
+++ b/.github/actions/php/action.yml
@@ -1,29 +1,29 @@
 name: Setup PHP
 
 runs:
-  using: 'composite'
-  steps:
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        tools: composer
-        extensions: mysql
-        coverage: none
+    using: 'composite'
+    steps:
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+              php-version: ${{ matrix.php }}
+              tools: composer
+              extensions: mysql
+              coverage: none
 
-    - name: Get Composer cache directory
-      id: composer-cache
-      shell: bash
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        - name: Get Composer cache directory
+          id: composer-cache
+          shell: bash
+          run: echo "dir=$(composer config cache-files-dir)" >> ${GITHUB_OUTPUT}
 
-    - name: Cache Composer packages
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-${{ matrix.php }}-
+        - name: Cache Composer packages
+          uses: actions/cache@v3
+          with:
+              path: ${{ steps.composer-cache.outputs.dir }}
+              key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+              restore-keys: |
+                  ${{ runner.os }}-php-${{ matrix.php }}-
 
-    - name: Install dependencies
-      shell: bash
-      run: composer install --prefer-dist --no-progress
+        - name: Install dependencies
+          shell: bash
+          run: composer install --prefer-dist --no-progress

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,27 +1,29 @@
 name: Coding Standards
 
 on:
-  pull_request:
-    branches: [develop, trunk]
-  workflow_dispatch:
+    pull_request:
+        branches: [develop, trunk]
+    push:
+        branches: [feature/mvp]
+    workflow_dispatch:
 
 jobs:
-  lint:
-    name: Check Coding Standards
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    lint:
+        name: Check Coding Standards
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
 
-      - name: Setup Node.js
-        uses: ./.github/actions/node
+            - name: Setup Node.js
+              uses: ./.github/actions/node
 
-      - name: JS check
-        shell: bash
-        run: npm run lint:js
+            - name: JS check
+              shell: bash
+              run: npm run lint:js
 
-      - name: WPCS check
-        uses: 10up/wpcs-action@stable
-        with:
-          enable_warnings: true
-          use_local_config: true
+            - name: WPCS check
+              uses: 10up/wpcs-action@stable
+              with:
+                  enable_warnings: true
+                  use_local_config: true

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -1,27 +1,29 @@
 name: JS Continuous Integration
 
 on:
-  pull_request:
-    branches: [develop, trunk]
-  workflow_dispatch:
+    pull_request:
+        branches: [develop, trunk]
+    push:
+        branches: [feature/mvp]
+    workflow_dispatch:
 
 jobs:
-  build:
-    name: Build plugin
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [16.x, 18.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    build:
+        name: Build plugin
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+                node-version: [16.x, 18.x]
+                os: [ubuntu-latest, macos-latest, windows-latest]
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
 
-      - name: Setup Node.js
-        uses: ./.github/actions/node
+            - name: Setup Node.js
+              uses: ./.github/actions/node
 
-      - name: Build package
-        shell: bash
-        run: npm run build --if-present
+            - name: Build package
+              shell: bash
+              run: npm run build --if-present

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.2', '7.4', '8.0']
+                php: ['7.4', '8.0', '8.1']
                 wp: ['latest']
         services:
             database:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -3,6 +3,8 @@ name: Test Suite
 on:
     pull_request:
         branches: [develop, trunk]
+    push:
+        branches: [feature/mvp]
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.4', '8.0', '8.1']
+                php: ['7.4', '8.0', '8.1', '8.2']
                 wp: ['latest']
         services:
             database:


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove PHP 7.2 from CI `test-suite.yml` workflow.

Add PHP 8.1 and 8.2 to CI `test-suite.yml` workflow.

Also `lint-staged` formatted the yaml files to match the prettier rules for yaml, which uses 4 spaces for tabs.

Also remove `set-output`, there was a warning it is depreciated and will be removed soon.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

The plugin header specifies minimum PHP support is 7.4. 