### PR TITLE
feature: add channel registry

### DIFF
--- a/includes/channels.php
+++ b/includes/channels.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Functions related to registering channels.
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+/**
+ * Register a notification channel.
+ *
+ * @param string|Channel $name  Channel name including namespace, or alternatively a complete
+ *                              Channel instance. In case a Channel is provided, the $args
+ *                              parameter will be ignored.
+ * @param array          $args  Optional. Array of channel arguments. Accepts any public property
+ *                              of `Channel`. See Channel::__construct() for information on
+ *                              accepted arguments. Default empty array.
+ * @return Channel|false The registered channel on success, or false on failure.
+ */
+function register_channel( $name, $args = array() ) {
+	return Channel_Registry::get_instance()->register( $name, $args );
+}
+
+/**
+ * Unregister a channel.
+ *
+ * @param string|Channel $name Channel name including namespace, or alternatively a complete
+ *                             Channel instance.
+ * @return Channel|false The unregistered channel on success, or false on failure.
+ */
+function unregister_channel( $name ) {
+	return Channel_Registry::get_instance()->unregister( $name );
+}
+
+// Register core notification channels.
+
+add_action(
+	'init',
+	function () {
+		register_channel(
+			new Channel(
+				'core/updates',
+				array(
+					'title'       => __( 'WordPress Updates', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'WordPress core update events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-install',
+				array(
+					'title'       => __( 'Plugin Install', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin install events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-uninstall',
+				array(
+					'title'       => __( 'Plugin Uninstall', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin uninstall events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-activate',
+				array(
+					'title'       => __( 'Plugin Activate', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin activation events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-deactivate',
+				array(
+					'title'       => __( 'Plugin Deactivate', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin deactivation events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/plugin-updates',
+				array(
+					'title'       => __( 'Plugin Update', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Plugin update events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/post-new',
+				array(
+					'title'       => __( 'New Post', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Post creation events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/post-edit',
+				array(
+					'title'       => __( 'Edit Post', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Post edit events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/post-delete',
+				array(
+					'title'       => __( 'Delete Post', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Post delete events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+
+		register_channel(
+			new Channel(
+				'core/comment-new',
+				array(
+					'title'       => __( 'New Comment', 'wp-feature-notifications' ),
+					'icon'        => 'wordpress',
+					'description' => __( 'Comment creation events.', 'wp-feature-notifications' ),
+				)
+			)
+		);
+	}
+);

--- a/includes/class-channel-registry.php
+++ b/includes/class-channel-registry.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Notifications API:Channel_Registry class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+/**
+ * Class used for interacting with channels.
+ */
+final class Channel_Registry {
+
+	/**
+	 * Registered channels, as `$name => $instance` pairs.
+	 *
+	 * @var Channel[]
+	 */
+	private $registered_channels = array();
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @var Channel_Registry|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Registers a channel.
+	 *
+	 * @see \WP\Notifications\Channel::__construct()
+	 *
+	 * @param string|Channel $name  Channel name including namespace, or alternatively a complete
+	 *                              Channel instance. In case a Channel is provided, the $args
+	 *                              parameter will be ignored.
+	 * @param array          $args  Optional. Array of channel arguments. Accepts any public property
+	 *                              of `Channel`. See Channel::__construct() for information on
+	 *                              accepted arguments. Default empty array.
+	 * @return Channel|false The registered channel on success, or false on failure.
+	 */
+	public function register( $name, $args = array() ) {
+		$channel = null;
+
+		if ( $name instanceof Channel ) {
+			$channel = $name;
+			$name    = $channel->name;
+		}
+
+		if ( ! is_string( $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Channel names must be strings.' ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		if ( preg_match( '/[A-Z]+/', $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Channel names must not contain uppercase characters.' ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		$name_matcher = '/^[a-z0-9-]+\/[a-z0-9-]+$/';
+		if ( ! preg_match( $name_matcher, $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Channel names must contain a namespace prefix. Example: my-plugin/my-channel' ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		if ( $this->is_registered( $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Channel name. */
+				sprintf( __( 'Channel "%s" is already registered.' ), $name ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		if ( ! $channel ) {
+			$channel = new Channel( $name, $args );
+		}
+
+		$this->registered_channels[ $channel->name ] = $channel;
+
+		return $channel;
+	}
+
+	/**
+	 * Unregister a channel.
+	 *
+	 * @param string|Channel $name Channel type name including namespace, or alternatively a complete
+	 *                             Channel instance.
+	 * @return Channel|false The unregistered channel on success, or false on failure.
+	 */
+	public function unregister( $name ) {
+		if ( $name instanceof Channel ) {
+			$name = $name->name;
+		}
+
+		if ( ! $this->is_registered( $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Channel name. */
+				sprintf( __( 'Channel "%s" is not registered.' ), $name ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		$unregistered_channel = $this->registered_channels[ $name ];
+		unset( $this->registered_channels[ $name ] );
+
+		return $unregistered_channel;
+	}
+
+	/**
+	 * Retrieves a registered channel.
+	 *
+	 * @param string $name Channel name including namespace.
+	 *
+	 * @return Channel|null The registered channel, or null if it is not registered.
+	 */
+	public function get_registered( $name ) {
+		if ( ! $this->is_registered( $name ) ) {
+			return null;
+		}
+
+		return $this->registered_channels[ $name ];
+	}
+
+	/**
+	 * Retrieves all registered channels.
+	 *
+	 * @return Channel[] Associative array of `$channel_name => $channel` pairs.
+	 */
+	public function get_all_registered() {
+		return $this->registered_channels;
+	}
+
+	/**
+	 * Checks if a channel is registered.
+	 *
+	 * @param string $name Chanel name including namespace.
+	 *
+	 * @return bool True if the channel is registered, false otherwise.
+	 */
+	public function is_registered( $name ) {
+		return isset( $this->registered_channels[ $name ] );
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @return Channel_Registry The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+}

--- a/includes/class-channel.php
+++ b/includes/class-channel.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Notifications API:Channel class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+use JsonSerializable;
+
+/**
+ * Class representing a channel.
+ *
+ * @see register_channel()
+ */
+class Channel implements JsonSerializable {
+	/**
+	 * Channel key.
+	 *
+	 * @var string
+	 */
+	public string $name;
+
+	/**
+	 * Human-readable channel label.
+	 *
+	 * @var string
+	 */
+	public string $title = '';
+
+	/**
+	 * Channel icon.
+	 *
+	 * @var string|null
+	 */
+	public $icon = null;
+
+
+	/**
+	 * Channel description.
+	 *
+	 * @var string|null
+	 */
+	public $description = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * Instantiates a Channel object.
+	 *
+	 * @see register_channel()
+	 *
+	 * @param string       $channel Channel name including namespace.
+	 * @param array|string $args    {
+	 *     Array or string of arguments for registering a channel. Supported arguments are
+	 *     described below.
+	 *
+	 *     @type string      $title       Human-readable channel label.
+	 *     @type string|null $icon        Optional channel icon.
+	 *     @type string|null $description Optional detailed channel description.
+	 * }
+	 */
+	public function __construct( string $channel, $args ) {
+		$parsed = wp_parse_args( $args );
+
+		$this->name        = $channel;
+		$this->title       = $parsed['title'];
+		$this->icon        = array_key_exists( 'icon', $parsed ) ? $parsed['icon'] : null;
+		$this->description = array_key_exists( 'description', $parsed ) ? $parsed['description'] : null;
+	}
+
+	/**
+	 * Specifies data which should be serialized to JSON.
+	 *
+	 * @return mixed Data which can be serialized by json_encode, which is a
+	 *               value of any type other than a resource.
+	 */
+	public function jsonSerialize(): mixed {
+		return array(
+			'name'        => $this->name,
+			'title'       => $this->title,
+			'icon'        => $this->icon,
+			'description' => $this->description,
+		);
+	}
+}

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -40,6 +40,9 @@ if ( ! defined( 'WP_FEATURE_NOTIFICATION_PLUGIN_DIR_URL' ) ) {
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/vendor/autoload.php';
 
 // Require interface/class declarations..
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-channel.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-channel-registry.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/channels.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/interface-exception.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/class-runtime-exception.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/class-invalid-recipient.php';


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Same as PR #251 but merging into `feature/mvp` branch.

Add a `Channel_Registry` class to register notification channels.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

To attempt registering channels in code.

Implementing the data model of PR #168 has the challenge of when and how to look up plugin registered channels. If channel data is stored in a database table and an integer `id` column is used to link a channel to subscription and messages, how does a plugin know the `id` of the channel it registered? This data would have to be looked up on message emit, and also there wouldn't be a good mechanism to prevent plugins from registering similarly named channels.

Using a registry similar block types might work well. The channel is registered in code and the channel name/key/slug (as in `core/post-edit`) would link a message source to its channel. Subscriptions could also use the same key to link users to channels. This would also allow checking for conflicts at channel registration.

Keeping in mind that if/when a plugin is uninstalled, a message has to contain all the data required to render, it is necessary to store channel key and title in the message.

Both systems have pros and cons. This strategy removes the need for a channel table, and simplifies the logic of emitting a message. Though it will result in duplication of data in the database.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- `Channel_Registry` class, heavy based on core `Block_Type_Registry`
- `Channel` class
- `register_channel` function

## Further considerations

- When/if a plugin is uninstalled its channel subscriptions would remain in the database subscriptions table. Though this is a very small table compared with the queue table. And remembering user preferences is probably normal behavior, so there is a seamless experience if a plugin is reinstalled.
- The channel `icon` could be stored in the message's `icon` column if/when a message doesn't specify it's own.
