### PR TITLE
feature: add channel list command

### DIFF
--- a/includes/class-command-line-interface.php
+++ b/includes/class-command-line-interface.php
@@ -28,6 +28,7 @@ class Command_Line_Interface {
 	 * Add CLI commands.
 	 */
 	static function add_commands() {
+		WP_CLI::add_command( 'notifications channel list', Commands\Channel_List::class );
 		WP_CLI::add_command( 'notifications seed-users', Commands\Seed_Users::class );
 	}
 }

--- a/includes/commands/class-channel-list.php
+++ b/includes/commands/class-channel-list.php
@@ -1,34 +1,55 @@
 <?php
-
-namespace WP\Notifications\Commands;
-
-use WP_CLI;
-use WP\Notifications;
-
 /**
- * Class Channel_List
- *
  * A WP-CLI command for inspecting notification channels.
  *
  * @package wordpress/wp-feature-notifications
  */
-class Channel_List {
+
+namespace WP\Notifications\Commands;
+
+use WP_CLI;
+use WP_CLI_Command;
+use WP\Notifications;
+
+/**
+ * Inspect the registered notification channels.
+ *
+ * @when after_wp_load
+ */
+class Channel_List extends WP_CLI_Command {
 
 	/**
-	 * List registered notification channels.
-	*
+	 * List all registered notification channels.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - count
+	 *   - yaml
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp notifications channel list
+	 *     # List all registered channels.
+	 *     $ wp notifications channel list
 	 *
 	 * @when after_wp_load
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$channels = Notifications\Channel_Registry::get_instance()->get_all_registered();
-		WP_CLI\Utils\format_items(
-			'table',
-			$channels,
-			'name,title'
+
+		$formatter = new WP_CLI\Formatter(
+			$assoc_args,
+			'name,title,icon'
 		);
+
+		$formatter->display_items( $channels );
 	}
 }

--- a/includes/commands/class-channel-list.php
+++ b/includes/commands/class-channel-list.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WP\Notifications\Commands;
+
+use WP_CLI;
+use WP\Notifications;
+
+/**
+ * Class Channel_List
+ *
+ * A WP-CLI command for inspecting notification channels.
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+class Channel_List {
+
+	/**
+	 * List registered notification channels.
+	*
+	 * ## EXAMPLES
+	 *
+	 *     wp notifications channel list
+	 *
+	 * @when after_wp_load
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$channels = Notifications\Channel_Registry::get_instance()->get_all_registered();
+		WP_CLI\Utils\format_items(
+			'table',
+			$channels,
+			'name,title'
+		);
+	}
+}

--- a/includes/commands/class-seed-users.php
+++ b/includes/commands/class-seed-users.php
@@ -4,7 +4,6 @@ namespace WP\Notifications\Commands;
 
 use Exception;
 
-use WP_User_Query;
 use WP_CLI;
 use Faker;
 
@@ -18,11 +17,9 @@ use Faker;
 class Seed_Users {
 
 	/**
-	 * @param Channel_Factory    $channel_factory
-	 * @param Channel_Repository $channel_repository
+	 * TODO is a constructor necessary?
 	 */
-	public function __construct() {
-	}
+	public function __construct() {}
 
 	/**
 	 * Seed the WordPress database with test users.
@@ -39,7 +36,7 @@ class Seed_Users {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp notifications seed-users --count=10 --preview
+	 *     wp notifications seed-users --count=10 --preview=true
 	 *
 	 * @when after_wp_load
 	 */
@@ -76,7 +73,7 @@ class Seed_Users {
 			WP_CLI\Utils\format_items(
 				'table',
 				$users,
-				'login,email,password,first_name,last_name'
+				'user_login,user_email,user_pass,role'
 			);
 		} else {
 			$progress = WP_CLI\Utils\make_progress_bar( 'Generating ', $count );
@@ -102,14 +99,6 @@ class Seed_Users {
 
 					$progress->tick();
 				}
-
-				$query = new WP_User_Query(
-					array(
-						'include' => $user_ids,
-					)
-				);
-
-				$result = array();
 
 				$progress->finish();
 			} catch ( Exception $e ) {

--- a/includes/commands/class-seed-users.php
+++ b/includes/commands/class-seed-users.php
@@ -17,11 +17,6 @@ use Faker;
 class Seed_Users {
 
 	/**
-	 * TODO is a constructor necessary?
-	 */
-	public function __construct() {}
-
-	/**
 	 * Seed the WordPress database with test users.
 	 *
 	 * ## OPTIONS

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -74,6 +74,7 @@ require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/persistence/class-a
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/persistence/class-wpdb-notification-repository.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/demo.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/restapi/class-notification-controller.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/commands/class-channel-list.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/commands/class-seed-users.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-command-line-interface.php';
 


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a `wp-cli` command to list the registered notification channels.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

To help with debugging and confirmation the channels are registered.