### PR TITLE
CSS - Moving to "purpose naming" convention

### DIFF
--- a/src/styles/components/bullet.scss
+++ b/src/styles/components/bullet.scss
@@ -4,7 +4,6 @@
 
 $bullet-width: 6px;
 
-
 #wpbody .wp-notification-wrap,
 #wpadminbar .wp-notifications.new {
 	position: relative;

--- a/src/styles/components/notification.scss
+++ b/src/styles/components/notification.scss
@@ -2,8 +2,8 @@
  * General notifications style
  */
 .wp-notification {
-	background: var(--wp-notify--color--white);
-	color: var(--wp-notify--color--default);
+	background: var(--wp-notify--color--background);
+	color: var(--wp-notify--color--primary);
 	overflow: hidden;
 	max-height: 600px;
 

--- a/src/styles/dashboard/notice.scss
+++ b/src/styles/dashboard/notice.scss
@@ -27,9 +27,19 @@
 		margin: 10px 0 var(--wp-notify--hub-element-bottom);
 		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 
+		// the notification left border
 		border-left-width: 4px;
 		border-left-style: solid;
-		border-color: var(--wp-notify--color--default);
+		border-color: var(--wp-notify--color--primary);
+
+		@media #{$breakpoint} {
+			grid-template-columns: auto;
+			gap: 50px;
+
+			.wp-notification-wrap {
+				order: 2;
+			}
+		}
 
 		/**
 		 * Will removes the top-margin from the first
@@ -72,7 +82,7 @@
 
 				&:hover,
 				&:focus {
-					background-color: var(--wp-notify--color--black-300);
+					background-color: $color-black-300;
 				}
 			}
 		}
@@ -86,14 +96,6 @@
 				width: 100%;
 				object-position: center;
 				object-fit: contain;
-			}
-		}
-
-		@media #{$breakpoint} {
-			grid-template-columns: auto;
-
-			.wp-notification-wrap {
-				order: 2;
 			}
 		}
 	}

--- a/src/styles/hub/admin-bar.scss
+++ b/src/styles/hub/admin-bar.scss
@@ -13,7 +13,7 @@
 	&:hover #wp-notifications-hub {
 
 		.ab-icon::before {
-			color: var(--wp-notify--color--white);
+			color: $color-white;
 		}
 	}
 
@@ -45,11 +45,11 @@
 		border-radius: 50%;
 		font-size: 0;
 
-		/* WP Editor / Alert Red */
-		background: var(--wp-notify--color--red);
+		/* the dot color */
+		background: $color-red;
 
-		/* Classic / Dark Gray 800 */
-		border: 1px solid var(--wp-notify--color--black-800);
+		/* the dot color border */
+		border: 1px solid $color-black-800;
 	}
 
 	/* Mobile */

--- a/src/styles/hub/elements.scss
+++ b/src/styles/hub/elements.scss
@@ -24,8 +24,8 @@
 		z-index: 2;
 		min-height: 50px;
 		top: 0;
-		background: var(--wp-notify--color--white);
-		box-shadow: 0 0 0 1px var(--wp-notify--color--white);
+		background: $color-white;
+		box-shadow: 0 0 0 1px $color-white;
 		padding: 0 var(--wp-notify--hub-spacing-horizontal) 10px;
 
 		.wp-notifications-action.mark-as-read {
@@ -53,7 +53,7 @@
 		&::before {
 			content: "";
 			display: block;
-			box-shadow: 0 1rem 24px 2px var(--wp-notify--color--default);
+			box-shadow: 0 1rem 24px 2px var(--wp-notify--color--primary);
 			width: 80%;
 			margin: auto 10%;
 			position: absolute;
@@ -70,9 +70,9 @@
 			height: 56px;
 			width: 100%;
 			text-align: center;
-			background: var(--wp-notify--color--white);
+			background: var(--wp-notify--color--background);
 			padding: 15px var(--wp-notify--hub-spacing-horizontal);
-			border-top: 1px solid var(--wp-notify--color--black-400);
+			border-top: 1px solid $color-black-400;
 
 			svg {
 				fill: var(--wp-notify--color--link);
@@ -91,7 +91,7 @@
 			// Outline the footer element if it is selected with tab
 			&:focus {
 				border-radius: 2px;
-				outline: 2px solid var(--wp-notify--color--black);
+				outline: 2px solid $color-black;
 			}
 		}
 	}

--- a/src/styles/hub/layout.scss
+++ b/src/styles/hub/layout.scss
@@ -10,8 +10,8 @@
 	flex-direction: column;
 	height: 100%;
 	padding: 30px 0 0;
-	background: var(--wp-notify--color--white);
-	box-shadow: 0 0 24px -16px var(--wp-notify--color--default);
+	background: var(--wp-notify--color--background);
+	box-shadow: 0 0 24px -16px var(--wp-notify--color--primary);
 	box-sizing: border-box;
 	overflow: hidden;
 

--- a/src/styles/hub/notice.scss
+++ b/src/styles/hub/notice.scss
@@ -21,7 +21,7 @@
 		// shows the selected item using the webkit default styling
 		&:focus-visible {
 			border-radius: 2px;
-			outline: 2px solid var(--wp-notify--color--black);
+			outline: 2px solid $color-black;
 		}
 
 		&-wrap {
@@ -64,7 +64,7 @@
 
 		&-icon {
 
-			background: var(--wp-notify--color--black-200);
+			background: $color-black-200;
 			border-radius: 8px;
 
 			.ab-icon {
@@ -73,7 +73,7 @@
 				line-height: 1;
 
 				&::before {
-					color: var(--wp-notify--color--white);
+					color: $color-white;
 					opacity: 0.9;
 				}
 			}
@@ -98,7 +98,7 @@
 		"alert": var(--wp-notify--color--error),
 		"warning": var(--wp-notify--color--warning),
 		"success": var(--wp-notify--color--success),
-		"info": var(--wp-notify--color--blue)
+		"info": var(--wp-notify--color--info)
 	);
 
 	@each $key, $value in $alertSeverity {

--- a/src/styles/vars.scss
+++ b/src/styles/vars.scss
@@ -1,34 +1,36 @@
 // Mobile breakpoint used in wp-admin.
 $breakpoint: "screen and (max-width: 782px)";
 
+// WP Notification Feature base colors
+$color-yellow: #ffb900;     // Yellow
+$color-green: #46b450;      // Green
+$color-red: #d94f4f;        // Alert Red
+$color-blue: #0071a1;       // Blue Dark 900
+$color-blue-light: #72aee6; // Blue 20
+
+// WP Notification Feature base tones
+$color-white: #fff;         // White
+$color-black-200: #e2e4e7; // Gray 200
+$color-black-300: #e8eaeb; // Gray 300
+$color-black-400: #c3c4c7; // Gray 400
+$color-black-500: #6c7781; // Gray 500
+$color-black-700: #444;    // Gray 700
+$color-black-800: #23282d; // Gray 800
+$color-black: #000;        // Black
+
 // https://make.wordpress.org/design/handbook/design-guide/foundations/colors/
 :root {
-	// WP Notification Feature base colors
-	--wp-notify--color--white: #fff;         // White
-	--wp-notify--color--black-200: #e2e4e7; // Gray 200
-	--wp-notify--color--black-300: #e8eaeb; // Gray 300
-	--wp-notify--color--black-400: #c3c4c7; // Gray 400
-	--wp-notify--color--black-500: #6c7781; // Gray 500
-	--wp-notify--color--black-700: #444;    // Gray 700
-	--wp-notify--color--black-800: #23282d; // Gray 800
-	--wp-notify--color--black: #000;        // Black
+	--wp-notify--color--primary: #{$color-black-700};
+	--wp-notify--color--secondary: #{$color-black-500};
+	--wp-notify--color--background: #{$color-white};
 
-	--wp-notify--color--yellow: #ffb900;     // Yellow
-	--wp-notify--color--green: #46b450;      // Green
-	--wp-notify--color--red: #d94f4f;        // Alert Red
-	--wp-notify--color--blue: #0071a1;       // Blue Dark 900
-	--wp-notify--color--blue-light: #72aee6; // Blue 20
-
-	--wp-notify--color--default: var(--wp-notify--color--black-700);
-	--wp-notify--color--secondary: var(--wp-notify--color--black-500);
-
-	--wp-notify--color--scrollbar: var(--wp-notify--color--black-300);
-	--wp-notify--color--link: var(--wp-notify--color--blue);
-	--wp-notify--color--link-active: var(--wp-notify--color--blue-light);
-	--wp-notify--color--error: var(--wp-notify--color--red);
-	--wp-notify--color--info: var(--wp-notify--color--blue);
-	--wp-notify--color--warning: var(--wp-notify--color--yellow);
-	--wp-notify--color--success: var(--wp-notify--color--green);
+	--wp-notify--color--scrollbar: #{$color-black-300};
+	--wp-notify--color--link: #{$color-blue};
+	--wp-notify--color--link-active: #{$color-blue-light};
+	--wp-notify--color--error: #{$color-red};
+	--wp-notify--color--info: #{$color-blue};
+	--wp-notify--color--warning: #{$color-yellow};
+	--wp-notify--color--success: #{$color-green};
 
 	// WP Notification Feature hub (admin top bar)
 	--wp-notify--hub-width: 320px;


### PR DESCRIPTION
## What?
Css custom props were definitely a great innovation and allow you to share the colors of your stylesheet. However, too many plugins end up creating their own color set libraries in the root and you end up with the opposite effect

## Why?
IMHO the problem arise because the name of the color is used to set the variable name, and this eventually forces all plugins to create a variable for each color used. This PR makes this plugin follow another method which is to use the names on the purpose that the variables have (and thus success, error etc)
Several articles that talk about this can be found (eg. [this](https://engineering.monday.com/how-we-stopped-using-color-names-and-move-to-purpose-naming/) or [this](https://www.freecodecamp.org/news/css-naming-conventions-that-will-save-you-hours-of-debugging-35cea737d849/)), it seems to me a very good improvement to do to clean up and simplify the style

## How?
```scss
:root {
  --wp-notify--color--red: #f00; // Red
  --wp-notify--color--error: var(--wp-notify--color--red);
}
```
to
```scss
$color-red: #d94f4f;
:root {
  --wp-notify--color--error: #{$color-red};
}
```