### PR TITLE
Move to @wordpress/escape-html and @wordpress/date packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,24 +3,25 @@
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
+	"dev": true,
 	"packages": {
 		"": {
 			"name": "wp-feature-notifications",
 			"version": "0.1.0",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"workspaces": [
 				"./storybook"
 			],
-			"dependencies": {
-				"dompurify": "^2.4.0"
-			},
 			"devDependencies": {
 				"@types/jest": "^29.5.0",
 				"@wordpress/api-fetch": "^6.27.0",
 				"@wordpress/components": "^23.7.0",
 				"@wordpress/data": "^9.0.0",
+				"@wordpress/date": "^4.31.0",
 				"@wordpress/e2e-test-utils": "^10.1.0",
 				"@wordpress/env": "^5.15.0",
+				"@wordpress/escape-html": "^2.31.0",
 				"@wordpress/i18n": "^4.30.0",
 				"@wordpress/icons": "^9.21.0",
 				"@wordpress/keyboard-shortcuts": "^4.7.0",
@@ -30,14 +31,13 @@
 				"husky": "^8.0.3",
 				"jest-puppeteer": "^6.2.0",
 				"lint-staged": "^13.2.0",
-				"moment": "^2.29.3",
 				"prettier": "npm:wp-prettier@^2.8.5",
 				"re-resizable": "^6.9.9",
 				"typescript": "^5.0.3"
 			},
 			"engines": {
 				"node": ">=14",
-				"npm": ">=6.9"
+				"npm": ">=7"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -7413,13 +7413,13 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.30.0.tgz",
-			"integrity": "sha512-Ip//fBmaYS8F6P933EXpjWmblX7KMs/f9WJ7E3B5tfuNLRETDUq0CTTEimtoEicdBowDAQeY0sRLPd+zLXqLfw==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.31.0.tgz",
+			"integrity": "sha512-ZoOL+zHRcNatfcQ4eDpGtQw9Ge6PI0W4jRxOU+InOrV71rSkbzJL3Oz+dYt79Xni2adxi5YnVyx7ZYf5XgfJLQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^3.30.0",
+				"@wordpress/deprecated": "^3.31.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -7444,13 +7444,13 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.30.0.tgz",
-			"integrity": "sha512-+Zk2wqDtvEkq9BY0SHeKHvywPn37hIsDkCyrRHChNhZYYluAzLS9mZKkFKjIuj6+dxYMINbkWcljA+HO0kdcQQ==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.31.0.tgz",
+			"integrity": "sha512-b3Ty/OCEKoPZU9Butku5W8cgiC509vmV0WkGLKeImO3uebVl6LipZt1w16uz7wSPNV8z7OY0UvelnKrydR2bcw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.30.0"
+				"@wordpress/hooks": "^3.31.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -7546,9 +7546,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "2.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.30.0.tgz",
-			"integrity": "sha512-A0FVcCPSfzCsuoLJOGCKOj3ygg6lWptugtyFcXoELG15AJ3ivfeJEeghZo77YpaWCmyCf0yTC56qbaAa2c48uw==",
+			"version": "2.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.31.0.tgz",
+			"integrity": "sha512-IZUeaXooSzCxVorfXpJEriY/zKbksFo8Q+QdZK/vzG1/0iDCwVOQJ5+o6UHo0ripVILWRxzfVS58YDGfTsca5g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -7627,9 +7627,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.30.0.tgz",
-			"integrity": "sha512-cvM5OWMQx0D2+wxvsTCI68LXy4cHz1Db97LliiQ+KprSBmYRG5Uy2PqtPv1sMlK8IOypKOlzmG5H5V1CwBN44A==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.31.0.tgz",
+			"integrity": "sha512-dtXTk6miFaqAQmtjuO1Ox11sdkJNMl/Wv402VlPI8Z3QBUyEAH+FMGoHbAwpy3AGHJJb5pFYSRQBNAgZMGZLIw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -8068,21 +8068,8 @@
 			}
 		},
 		"node_modules/@wordpress/wp-feature-notifications": {
-			"name": "wp-feature-notifications",
-			"version": "0.1.0",
-			"resolved": "file:",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"workspaces": [
-				"./storybook"
-			],
-			"dependencies": {
-				"dompurify": "^2.4.0"
-			},
-			"engines": {
-				"node": ">=14",
-				"npm": ">=6.9"
-			}
+			"resolved": "",
+			"link": true
 		},
 		"node_modules/@wordpress/wp-feature-notifications-stories": {
 			"resolved": "storybook",
@@ -11262,11 +11249,6 @@
 			"funding": {
 				"url": "https://github.com/fb55/domhandler?sponsor=1"
 			}
-		},
-		"node_modules/dompurify": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
-			"integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
 		},
 		"node_modules/domutils": {
 			"version": "2.8.0",
@@ -24253,6 +24235,7 @@
 			}
 		},
 		"storybook": {
+			"name": "@wordpress/wp-feature-notifications-stories",
 			"version": "1.0.0",
 			"devDependencies": {
 				"@storybook/addon-a11y": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,10 @@
 		"@wordpress/api-fetch": "^6.27.0",
 		"@wordpress/components": "^23.7.0",
 		"@wordpress/data": "^9.0.0",
+		"@wordpress/date": "^4.31.0",
 		"@wordpress/e2e-test-utils": "^10.1.0",
 		"@wordpress/env": "^5.15.0",
+		"@wordpress/escape-html": "^2.31.0",
 		"@wordpress/i18n": "^4.30.0",
 		"@wordpress/icons": "^9.21.0",
 		"@wordpress/keyboard-shortcuts": "^4.7.0",
@@ -71,13 +73,9 @@
 		"husky": "^8.0.3",
 		"jest-puppeteer": "^6.2.0",
 		"lint-staged": "^13.2.0",
-		"moment": "^2.29.3",
 		"prettier": "npm:wp-prettier@^2.8.5",
 		"re-resizable": "^6.9.9",
 		"typescript": "^5.0.3"
-	},
-	"dependencies": {
-		"dompurify": "^2.4.0"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"

--- a/src/scripts/components/NoticeMeta.js
+++ b/src/scripts/components/NoticeMeta.js
@@ -1,4 +1,4 @@
-import { dateI18n } from '@wordpress/date';
+import { noticeDateFormat } from '../utils';
 
 /**
  * The notice metadata, for example the source of the notification or the date
@@ -10,8 +10,6 @@ import { dateI18n } from '@wordpress/date';
 export const NoticeMeta = ( { date, source } ) => (
 	<p className="wp-notification-meta">
 		<span className="name">{ source }</span> { '\u2022 ' }
-		<span className="date">
-			{ dateI18n( 'l jS F Y - h:i A', date, true ) }
-		</span>
+		<span className="date">{ noticeDateFormat( date ) }</span>
 	</p>
 );

--- a/src/scripts/components/NoticeMeta.js
+++ b/src/scripts/components/NoticeMeta.js
@@ -1,15 +1,17 @@
-import * as moment from 'moment/moment';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * The notice metadata, for example the source of the notification or the date
  *
  * @param {Object} props
- * @param {number} props.date   The date of the notification.
+ * @param {string} props.date   The date of the notification.
  * @param {string} props.source The source of the notification.
  */
 export const NoticeMeta = ( { date, source } ) => (
 	<p className="wp-notification-meta">
 		<span className="name">{ source }</span> { '\u2022 ' }
-		<span className="date">{ moment( date ).fromNow() }</span>
+		<span className="date">
+			{ dateI18n( 'l jS F Y - h:i A', date, true ) }
+		</span>
 	</p>
 );

--- a/src/scripts/components/NoticeMeta.js
+++ b/src/scripts/components/NoticeMeta.js
@@ -1,15 +1,15 @@
-import { noticeDateFormat } from '../utils';
+import { formatDate } from '../utils';
 
 /**
  * The notice metadata, for example the source of the notification or the date
  *
  * @param {Object} props
- * @param {string} props.date   The date of the notification.
+ * @param {number} props.date   The date of the notification.
  * @param {string} props.source The source of the notification.
  */
 export const NoticeMeta = ( { date, source } ) => (
 	<p className="wp-notification-meta">
 		<span className="name">{ source }</span> { '\u2022 ' }
-		<span className="date">{ noticeDateFormat( date ) }</span>
+		<span className="date">{ formatDate( date ) }</span>
 	</p>
 );

--- a/src/scripts/utils/index.js
+++ b/src/scripts/utils/index.js
@@ -59,13 +59,14 @@ export const nowInSeconds = () => {
 };
 
 /**
- * Convert the date from epoch to human-readable format.
+ * Format the date from epoch to human-readable format.
  *
- * @param {string} date The date to convert.
+ * @param {number} date The date to convert in epoch format.
+ *
  * @return {string} The date in human-readable format.
  */
-export const noticeDateFormat = ( date ) => {
-	return dateI18n( 'l jS F Y - h:i A', date, true );
+export const formatDate = ( date ) => {
+	return dateI18n( 'l jS F Y - h:i A', new Date( date ), true );
 };
 
 /**

--- a/src/scripts/utils/index.js
+++ b/src/scripts/utils/index.js
@@ -1,6 +1,7 @@
 import { NOTIFY_NAMESPACE } from '../store/constants';
 import { WEEK_IN_SECONDS } from '../components/NoticesArea';
 import { dispatch } from '@wordpress/data';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * @typedef {import('../store').Notice} Notice
@@ -55,6 +56,16 @@ export const dateToSeconds = ( date ) => {
  */
 export const nowInSeconds = () => {
 	return Math.floor( Date.now() * 0.001 );
+};
+
+/**
+ * Convert the date from epoch to human-readable format.
+ *
+ * @param {string} date The date to convert.
+ * @return {string} The date in human-readable format.
+ */
+export const noticeDateFormat = ( date ) => {
+	return dateI18n( 'l jS F Y - h:i A', date, true );
 };
 
 /**

--- a/src/scripts/utils/sanitization.js
+++ b/src/scripts/utils/sanitization.js
@@ -1,14 +1,13 @@
-import DOMPurify from 'dompurify';
+import { escapeHTML } from '@wordpress/escape-html';
 
 /**
  * It takes a string and returns a sanitized version of that string.
  *
- * @param {string} string  - The text to be purified.
- * @param {Object} options - https://github.com/cure53/DOMPurify#can-i-configure-dompurify
+ * @param {string} string - The text to be purified.
  * @return {{ __html: string }} The sanitized string.
  */
-export const purify = ( string, options = {} ) => {
+export const purify = ( string ) => {
 	return {
-		__html: DOMPurify.sanitize( string, options ),
+		__html: escapeHTML( string ),
 	};
 };


### PR DESCRIPTION
## What?
Initially (out of habit) I had used the Moment and domPurify packages, but similar things already exist in the Gutenberg repo and it is definitely better to use these, since now the compiled sources weigh a tenth as much as before.

## How?
I make amends and this PR updates to WP built in packages 