### PR TITLE
feature: use datetime strings in fake api data

### DIFF
--- a/includes/restapi/fake_api.json
+++ b/includes/restapi/fake_api.json
@@ -4,6 +4,7 @@
 		"context": "dashboard",
 		"title": "Try this new Notification feature",
 		"source": "#WP-Notify",
+		"date": "2023-04-15T19:35:56",
 		"message": "👋 Hello from the WP Feature Notifications team! Thank you for testing out the plugin. You might want to give it a try so click on the bell icon on the right side of the adminbar.",
 		"dismissible": false,
 		"icon": {
@@ -12,110 +13,110 @@
 		"action": {
 			"acceptMessage": "Check out the source",
 			"acceptLink": "https://github.com/WordPress/wp-feature-notifications"
-		},
-		"date": "2023-04-15T19:35:56"
+		}
 	},
 	{
 		"id": 14,
 		"title": "Message variant #1 (copy)",
+		"date": "2023-04-15T16:13:48",
+		"dismissible": true,
 		"action": {
-			"acceptMessage": "TEST",
+			"acceptMessage": "Test",
 			"acceptLink": "#"
-		},
-		"date": "2023-04-15T16:13:48"
+		}
 	},
 	{
 		"id": 13,
 		"context": "adminbar",
 		"title": "Message variant #2",
 		"source": "#WP-Notify",
+		"date": "2023-04-13T15:41:53",
 		"message": "This is an example of on-page message variant #2. It has a title, a message, a custom date, an action button with a URL, is dismissable, but has no images.",
 		"dismissible": true,
-		"unread": true,
+		"status": "new",
 		"action": {
-			"acceptMessage": "OK",
+			"acceptMessage": "Ok",
 			"acceptLink": "#"
-		},
-		"date": "2023-04-13T15:41:53"
+		}
 	},
 	{
 		"id": 12,
 		"title": "WordPress",
 		"message": "WordPress was successfully updated to version 6.1",
+		"date": "2023-04-13T12:48:37",
 		"source": "WordPress",
-		"unread": true,
+		"status": "new",
 		"action": {
 			"acceptMessage": "Read what's new in 6.1",
 			"acceptLink": "#"
-		},
-		"date": "2023-04-13T12:48:37"
+		}
 	},
 	{
 		"id": 11,
 		"message": "WordPress was successfully updated to version 5.9.",
 		"source": "WordPress",
+		"date": "2023-04-13T10:42:45",
 		"image": {
 			"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" id=\"Layer_1\" x=\"0px\" y=\"0px\" width=\"64px\" height=\"64px\" viewBox=\"0 0 64 64\" enable-background=\"new 0 0 64 64\" xml:space=\"preserve\"><style>.style0{fill:\t#0073aa;}</style><g><g><path d=\"M4.548 31.999c0 10.9 6.3 20.3 15.5 24.706L6.925 20.827C5.402 24.2 4.5 28 4.5 31.999z M50.531 30.614c0-3.394-1.219-5.742-2.264-7.57c-1.391-2.263-2.695-4.177-2.695-6.439c0-2.523 1.912-4.872 4.609-4.872 c0.121 0 0.2 0 0.4 0.022C45.653 7.3 39.1 4.5 32 4.548c-9.591 0-18.027 4.921-22.936 12.4 c0.645 0 1.3 0 1.8 0.033c2.871 0 7.316-0.349 7.316-0.349c1.479-0.086 1.7 2.1 0.2 2.3 c0 0-1.487 0.174-3.142 0.261l9.997 29.735l6.008-18.017l-4.276-11.718c-1.479-0.087-2.879-0.261-2.879-0.261 c-1.48-0.087-1.306-2.349 0.174-2.262c0 0 4.5 0.3 7.2 0.349c2.87 0 7.317-0.349 7.317-0.349 c1.479-0.086 1.7 2.1 0.2 2.262c0 0-1.489 0.174-3.142 0.261l9.92 29.508l2.739-9.148 C49.628 35.7 50.5 33 50.5 30.614z M32.481 34.4l-8.237 23.934c2.46 0.7 5.1 1.1 7.8 1.1 c3.197 0 6.262-0.552 9.116-1.556c-0.072-0.118-0.141-0.243-0.196-0.379L32.481 34.4z M56.088 18.8 c0.119 0.9 0.2 1.8 0.2 2.823c0 2.785-0.521 5.916-2.088 9.832l-8.385 24.242c8.161-4.758 13.65-13.6 13.65-23.728 C59.451 27.2 58.2 22.7 56.1 18.83z M32 0c-17.645 0-32 14.355-32 32C0 49.6 14.4 64 32 64s32-14.355 32-32.001 C64 14.4 49.6 0 32 0z M32 62.533c-16.835 0-30.533-13.698-30.533-30.534C1.467 15.2 15.2 1.5 32 1.5 s30.534 13.7 30.5 30.532C62.533 48.8 48.8 62.5 32 62.533z\" class=\"style0\"/></g></g></svg>"
-		},
-		"date": "2023-04-13T10:42:45"
+		}
 	},
 	{
 		"id": 10,
 		"title": "WordPress",
 		"message": "WordPress was successfully updated to version 6.1",
 		"source": "WordPress",
+		"date": "2023-04-11T18:28:08",
 		"action": {
 			"acceptMessage": "Read what's new in 6.1",
 			"acceptLink": "#"
-		},
-		"date": "2023-04-11T18:28:08"
+		}
 	},
 	{
 		"id": 9,
 		"title": "WordPress",
 		"message": "WordPress was successfully updated to version 6.1",
 		"source": "WordPress",
+		"date": "2023-04-11T10:52:09",
 		"action": {
 			"acceptMessage": "Read what's new in 6.1",
 			"acceptLink": "#"
-		},
-		"date": "2023-04-11T10:52:09"
+		}
 	},
 	{
 		"id": 8,
 		"message": "There is a new version of Contact Form 7 available.",
 		"source": "Plugins Updates",
+		"date": "2023-04-10T20:38:51",
 		"icon": {
 			"src": "https://ps.w.org/contact-form-7/assets/icon-256x256.png"
 		},
 		"action": {
 			"acceptMessage": "Update now",
 			"acceptLink": "#"
-		},
-		"date": "2023-04-10T20:38:51"
+		}
 	},
 	{
 		"id": 7,
 		"title": "Akismet",
 		"source": "Akismet",
+		"date": "2023-04-10T20:05:51",
 		"icon": {
 			"src": "https://ps.w.org/akismet/assets/icon-256x256.png"
 		},
 		"action": {
 			"acceptMessage": "Your API key is no longer valid.",
 			"acceptLink": "#"
-		},
-		"date": "2023-04-10T20:05:51"
+		}
 	},
 	{
 		"id": 6,
 		"title": "Default",
 		"acceptLink": "#",
 		"source": "Wordpress",
+		"date": "2023-04-08T05:07:02",
 		"icon": {
 			"dashicons": "paperclip"
-		},
-		"date": "2023-04-08T05:07:02"
+		}
 	},
 	{
 		"id": 5,
@@ -123,20 +124,20 @@
 		"title": "Site Health status",
 		"message": "Your site has critical issues that should be addressed",
 		"source": "Wordpress",
+		"date": "2023-04-07T22:59:54",
 		"icon": {
 			"dashicons": "sos"
-		},
-		"date": "2023-04-07T22:59:54"
+		}
 	},
 	{
 		"id": 4,
 		"severity": "warning",
 		"title": "Some plugins needs to be updated",
 		"source": "Wordpress",
+		"date": "2023-04-05T16:47:41",
 		"icon": {
 			"dashicons": "admin-plugins"
-		},
-		"date": "2023-04-05T16:47:41"
+		}
 	},
 	{
 		"id": 3,
@@ -144,27 +145,27 @@
 		"title": "Word Camp Europe 2023",
 		"message": "Word Camp was successfully updated to version 2023",
 		"source": "Wordpress",
+		"date": "2023-04-05T15:39:49",
 		"icon": {
 			"dashicons": "megaphone"
-		},
-		"date": "2023-04-05T15:39:49"
+		}
 	},
 	{
 		"id": 2,
 		"message": "WordPress User has left a message on Lorem Ipsum.",
 		"source": "Comment",
+		"date": "2023-04-03T04:08:11",
 		"icon": {
 			"src": "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y"
-		},
-		"date": "2023-04-03T04:08:11"
+		}
 	},
 	{
 		"id": 1,
 		"message": "WordPress User has left a message on Lorem Ipsum.",
 		"source": "Comment",
+		"date": "2023-04-02T14:46:49",
 		"icon": {
 			"src": "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y"
-		},
-		"date": "2023-04-02T14:46:49"
+		}
 	}
 ]

--- a/includes/restapi/fake_api.json
+++ b/includes/restapi/fake_api.json
@@ -4,7 +4,6 @@
 		"context": "dashboard",
 		"title": "Try this new Notification feature",
 		"source": "#WP-Notify",
-		"date": 1680974130,
 		"message": "👋 Hello from the WP Feature Notifications team! Thank you for testing out the plugin. You might want to give it a try so click on the bell icon on the right side of the adminbar.",
 		"dismissible": false,
 		"icon": {
@@ -13,110 +12,110 @@
 		"action": {
 			"acceptMessage": "Check out the source",
 			"acceptLink": "https://github.com/WordPress/wp-feature-notifications"
-		}
+		},
+		"date": "2023-04-15T19:35:56"
 	},
 	{
 		"id": 14,
 		"title": "Message variant #1 (copy)",
-		"date": 1680799521,
-		"dismissible": true,
 		"action": {
-			"acceptMessage": "Test",
+			"acceptMessage": "TEST",
 			"acceptLink": "#"
-		}
+		},
+		"date": "2023-04-15T16:13:48"
 	},
 	{
 		"id": 13,
 		"context": "adminbar",
 		"title": "Message variant #2",
 		"source": "#WP-Notify",
-		"date": 1680744049,
 		"message": "This is an example of on-page message variant #2. It has a title, a message, a custom date, an action button with a URL, is dismissable, but has no images.",
 		"dismissible": true,
-		"status": "new",
+		"unread": true,
 		"action": {
-			"acceptMessage": "Ok",
+			"acceptMessage": "OK",
 			"acceptLink": "#"
-		}
+		},
+		"date": "2023-04-13T15:41:53"
 	},
 	{
 		"id": 12,
 		"title": "WordPress",
 		"message": "WordPress was successfully updated to version 6.1",
-		"date": 1680702629,
 		"source": "WordPress",
-		"status": "new",
+		"unread": true,
 		"action": {
 			"acceptMessage": "Read what's new in 6.1",
 			"acceptLink": "#"
-		}
+		},
+		"date": "2023-04-13T12:48:37"
 	},
 	{
 		"id": 11,
 		"message": "WordPress was successfully updated to version 5.9.",
 		"source": "WordPress",
-		"date": 1680699690,
 		"image": {
 			"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" id=\"Layer_1\" x=\"0px\" y=\"0px\" width=\"64px\" height=\"64px\" viewBox=\"0 0 64 64\" enable-background=\"new 0 0 64 64\" xml:space=\"preserve\"><style>.style0{fill:\t#0073aa;}</style><g><g><path d=\"M4.548 31.999c0 10.9 6.3 20.3 15.5 24.706L6.925 20.827C5.402 24.2 4.5 28 4.5 31.999z M50.531 30.614c0-3.394-1.219-5.742-2.264-7.57c-1.391-2.263-2.695-4.177-2.695-6.439c0-2.523 1.912-4.872 4.609-4.872 c0.121 0 0.2 0 0.4 0.022C45.653 7.3 39.1 4.5 32 4.548c-9.591 0-18.027 4.921-22.936 12.4 c0.645 0 1.3 0 1.8 0.033c2.871 0 7.316-0.349 7.316-0.349c1.479-0.086 1.7 2.1 0.2 2.3 c0 0-1.487 0.174-3.142 0.261l9.997 29.735l6.008-18.017l-4.276-11.718c-1.479-0.087-2.879-0.261-2.879-0.261 c-1.48-0.087-1.306-2.349 0.174-2.262c0 0 4.5 0.3 7.2 0.349c2.87 0 7.317-0.349 7.317-0.349 c1.479-0.086 1.7 2.1 0.2 2.262c0 0-1.489 0.174-3.142 0.261l9.92 29.508l2.739-9.148 C49.628 35.7 50.5 33 50.5 30.614z M32.481 34.4l-8.237 23.934c2.46 0.7 5.1 1.1 7.8 1.1 c3.197 0 6.262-0.552 9.116-1.556c-0.072-0.118-0.141-0.243-0.196-0.379L32.481 34.4z M56.088 18.8 c0.119 0.9 0.2 1.8 0.2 2.823c0 2.785-0.521 5.916-2.088 9.832l-8.385 24.242c8.161-4.758 13.65-13.6 13.65-23.728 C59.451 27.2 58.2 22.7 56.1 18.83z M32 0c-17.645 0-32 14.355-32 32C0 49.6 14.4 64 32 64s32-14.355 32-32.001 C64 14.4 49.6 0 32 0z M32 62.533c-16.835 0-30.533-13.698-30.533-30.534C1.467 15.2 15.2 1.5 32 1.5 s30.534 13.7 30.5 30.532C62.533 48.8 48.8 62.5 32 62.533z\" class=\"style0\"/></g></g></svg>"
-		}
+		},
+		"date": "2023-04-13T10:42:45"
 	},
 	{
 		"id": 10,
 		"title": "WordPress",
 		"message": "WordPress was successfully updated to version 6.1",
 		"source": "WordPress",
-		"date": 1680652801,
 		"action": {
 			"acceptMessage": "Read what's new in 6.1",
 			"acceptLink": "#"
-		}
+		},
+		"date": "2023-04-11T18:28:08"
 	},
 	{
 		"id": 9,
 		"title": "WordPress",
 		"message": "WordPress was successfully updated to version 6.1",
 		"source": "WordPress",
-		"date": 1680406684,
 		"action": {
 			"acceptMessage": "Read what's new in 6.1",
 			"acceptLink": "#"
-		}
+		},
+		"date": "2023-04-11T10:52:09"
 	},
 	{
 		"id": 8,
 		"message": "There is a new version of Contact Form 7 available.",
 		"source": "Plugins Updates",
-		"date": 1680296658,
 		"icon": {
 			"src": "https://ps.w.org/contact-form-7/assets/icon-256x256.png"
 		},
 		"action": {
 			"acceptMessage": "Update now",
 			"acceptLink": "#"
-		}
+		},
+		"date": "2023-04-10T20:38:51"
 	},
 	{
 		"id": 7,
 		"title": "Akismet",
 		"source": "Akismet",
-		"date": 1680155149,
 		"icon": {
 			"src": "https://ps.w.org/akismet/assets/icon-256x256.png"
 		},
 		"action": {
 			"acceptMessage": "Your API key is no longer valid.",
 			"acceptLink": "#"
-		}
+		},
+		"date": "2023-04-10T20:05:51"
 	},
 	{
 		"id": 6,
 		"title": "Default",
 		"acceptLink": "#",
 		"source": "Wordpress",
-		"date": 1680126176,
 		"icon": {
 			"dashicons": "paperclip"
-		}
+		},
+		"date": "2023-04-08T05:07:02"
 	},
 	{
 		"id": 5,
@@ -124,20 +123,20 @@
 		"title": "Site Health status",
 		"message": "Your site has critical issues that should be addressed",
 		"source": "Wordpress",
-		"date": 1680106280,
 		"icon": {
 			"dashicons": "sos"
-		}
+		},
+		"date": "2023-04-07T22:59:54"
 	},
 	{
 		"id": 4,
 		"severity": "warning",
 		"title": "Some plugins needs to be updated",
 		"source": "Wordpress",
-		"date": 1679953118,
 		"icon": {
 			"dashicons": "admin-plugins"
-		}
+		},
+		"date": "2023-04-05T16:47:41"
 	},
 	{
 		"id": 3,
@@ -145,27 +144,27 @@
 		"title": "Word Camp Europe 2023",
 		"message": "Word Camp was successfully updated to version 2023",
 		"source": "Wordpress",
-		"date": 1679915144,
 		"icon": {
 			"dashicons": "megaphone"
-		}
+		},
+		"date": "2023-04-05T15:39:49"
 	},
 	{
 		"id": 2,
 		"message": "WordPress User has left a message on Lorem Ipsum.",
 		"source": "Comment",
-		"date": 1679903259,
 		"icon": {
 			"src": "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y"
-		}
+		},
+		"date": "2023-04-03T04:08:11"
 	},
 	{
 		"id": 1,
 		"message": "WordPress User has left a message on Lorem Ipsum.",
 		"source": "Comment",
-		"date": 1679863907,
 		"icon": {
 			"src": "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y"
-		}
+		},
+		"date": "2023-04-02T14:46:49"
 	}
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
 		"": {
 			"name": "wp-feature-notifications",
 			"version": "0.1.0",
-			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"workspaces": [
 				"./storybook"
@@ -8068,8 +8067,18 @@
 			}
 		},
 		"node_modules/@wordpress/wp-feature-notifications": {
-			"resolved": "",
-			"link": true
+			"name": "wp-feature-notifications",
+			"version": "0.1.0",
+			"resolved": "file:",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"workspaces": [
+				"./storybook"
+			],
+			"engines": {
+				"node": ">=14",
+				"npm": ">=7"
+			}
 		},
 		"node_modules/@wordpress/wp-feature-notifications-stories": {
 			"resolved": "storybook",

--- a/src/scripts/components/Drawer.js
+++ b/src/scripts/components/Drawer.js
@@ -3,7 +3,7 @@ import { NoticesArea } from './NoticesArea';
 import { Resizable } from 're-resizable';
 import { useState } from '@wordpress/element';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
-import { HUB_WIDTH } from '../store/constants';
+import { HUB_WIDTH } from '../constants';
 
 /**
  * This is a React component that renders a resizable drawer for displaying notifications.

--- a/src/scripts/components/Notice.js
+++ b/src/scripts/components/Notice.js
@@ -11,11 +11,12 @@ import { NoticeActions } from './NoticeAction';
 // Import utilities
 // @ts-ignore
 import classnames from 'classnames';
+import { STORE_NAMESPACE } from '../constants';
 import { purify } from '../utils/sanitization';
-import { defaultContext, NOTIFY_NAMESPACE } from '../store/constants';
+import { defaultContext } from '../store/constants';
 import { dispatch } from '@wordpress/data';
 import { NoticeMeta } from './NoticeMeta';
-import { delay, nowInSeconds } from '../utils';
+import { delay } from '../utils';
 
 /**
  * @typedef {import('../store').Notice} Notice
@@ -33,7 +34,7 @@ export const Notice = ( props ) => {
 	const {
 		action,
 		context = defaultContext,
-		date = nowInSeconds(),
+		date = new Date(),
 		dismissLabel,
 		dismissible,
 		icon,
@@ -49,13 +50,13 @@ export const Notice = ( props ) => {
 	 * Dismiss the target notification
 	 */
 	function dismissNotice() {
-		dispatch( NOTIFY_NAMESPACE ).updateNotice( {
+		dispatch( STORE_NAMESPACE ).updateNotice( {
 			id,
 			status: 'dismissed',
 		} );
 		// TODO missing exit animation
 		delay( 500 ).then( () =>
-			dispatch( NOTIFY_NAMESPACE ).removeNotice( id )
+			dispatch( STORE_NAMESPACE ).removeNotice( id )
 		);
 	}
 
@@ -79,7 +80,7 @@ export const Notice = ( props ) => {
 					onDismiss={ dismissNotice }
 					context={ context }
 				/>
-				<NoticeMeta date={ date * 1000 } source={ source } />
+				<NoticeMeta date={ date } source={ source } />
 			</div>
 
 			<NoticeIcon

--- a/src/scripts/components/NoticeMeta.js
+++ b/src/scripts/components/NoticeMeta.js
@@ -4,7 +4,7 @@ import { formatDate } from '../utils';
  * The notice metadata, for example the source of the notification or the date
  *
  * @param {Object} props
- * @param {number} props.date   The date of the notification.
+ * @param {Date}   props.date   The date of the notification.
  * @param {string} props.source The source of the notification.
  */
 export const NoticeMeta = ( { date, source } ) => (

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -1,0 +1,19 @@
+/**
+ * WP Notification Feature namespace.
+ */
+export const STORE_NAMESPACE = /** @type {const} */ 'core/wp-notifications';
+
+/**
+ * API_PATH WP Notification Feature rest api path.
+ */
+export const API_PATH = /** @type {const} */ '/wp/v2/notifications/';
+
+/**
+ * The width of the notification hub.
+ */
+export const HUB_WIDTH = /** @type {const} */ 320;
+
+/**
+ * The number of milliseconds in a week.
+ */
+export const WEEK_IN_MILLISECONDS = /** @type {const} */ ( 604800000 );

--- a/src/scripts/demo/index.js
+++ b/src/scripts/demo/index.js
@@ -2,7 +2,7 @@
  * On load listen for metabox events like submit, clear etc
  */
 import { dispatch } from '@wordpress/data';
-import { NOTIFY_NAMESPACE } from '../store/constants';
+import { STORE_NAMESPACE } from '../constants';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -33,7 +33,7 @@ window.addEventListener( 'load', () => {
 					)
 				).value || __( 'Notification default text' );
 
-			dispatch( NOTIFY_NAMESPACE ).addNotice(
+			dispatch( STORE_NAMESPACE ).addNotice(
 				/** @type {Notice} */ ( {
 					title,
 					message,

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -2,7 +2,8 @@
 import { dispatch, select } from '@wordpress/data';
 
 /** The store default data */
-import { contexts, NOTIFY_NAMESPACE } from './store/constants';
+import { STORE_NAMESPACE } from './constants';
+import { contexts } from './store/constants';
 import { addContext } from './utils/init';
 
 /**
@@ -22,14 +23,14 @@ const notify = {
 	/**
 	 * Fetch for new notices
 	 */
-	fetchUpdates: () => select( NOTIFY_NAMESPACE ).fetchUpdates(),
+	fetchUpdates: () => select( STORE_NAMESPACE ).fetchUpdates(),
 
 	/**
 	 * List all notifications or those of a particular context
 	 *
 	 * @param {string} context
 	 */
-	get: ( context = '' ) => select( NOTIFY_NAMESPACE ).getNotices( context ),
+	get: ( context = '' ) => select( STORE_NAMESPACE ).getNotices( context ),
 
 	/**
 	 * Search for a notification by key or term (term is optional, returns an array of objects)
@@ -43,21 +44,21 @@ const notify = {
 	 * notify.find("hello", {term: 'title'}) // [{ 'id': 5, title: "hello", location: "dashboard", ... }, {...}]
 	 * ```
 	 */
-	find: ( term, args ) => select( NOTIFY_NAMESPACE ).findNotice( term, args ),
+	find: ( term, args ) => select( STORE_NAMESPACE ).findNotice( term, args ),
 
 	/**
 	 * Add a new notification
 	 *
 	 * @param {Notice} payload
 	 */
-	add: ( payload ) => dispatch( NOTIFY_NAMESPACE ).addNotice( payload ),
+	add: ( payload ) => dispatch( STORE_NAMESPACE ).addNotice( payload ),
 
 	/**
 	 * Remove a notification by key
 	 *
 	 * @param {number} id
 	 */
-	remove: ( id ) => dispatch( NOTIFY_NAMESPACE ).removeNotice( id ),
+	remove: ( id ) => dispatch( STORE_NAMESPACE ).removeNotice( id ),
 
 	/**
 	 * Clear all notifications
@@ -65,7 +66,7 @@ const notify = {
 	 * @param {string} context
 	 */
 	clear: ( context = 'adminbar' ) =>
-		dispatch( NOTIFY_NAMESPACE ).clear( context ),
+		dispatch( STORE_NAMESPACE ).clear( context ),
 };
 
 /** Appends the wp-notify instance to window.wp in order to provide a public API */
@@ -77,11 +78,11 @@ window.wp.notify = notify;
  * @param {string} context
  */
 contexts.forEach( ( context ) =>
-	select( NOTIFY_NAMESPACE ).registerContext( context )
+	select( STORE_NAMESPACE ).registerContext( context )
 );
 
 /** after registering contexts we could fetch the notifications */
-select( NOTIFY_NAMESPACE ).fetchUpdates();
+select( STORE_NAMESPACE ).fetchUpdates();
 
 /**
  * Loops into contexts and adds a NoticesArea component for each one

--- a/src/scripts/store/actions.js
+++ b/src/scripts/store/actions.js
@@ -12,7 +12,7 @@
  */
 export const hydrate = ( payload ) => {
 	return {
-		type: /** @type {'HYDRATE'} */ ( 'HYDRATE' ),
+		type: /** @type {const} */ ( 'HYDRATE' ),
 		payload,
 	};
 };
@@ -25,7 +25,7 @@ export const hydrate = ( payload ) => {
  */
 export const clear = ( context ) => {
 	return {
-		type: /** @type {'CLEAR'} */ ( 'CLEAR' ),
+		type: /** @type {const} */ ( 'CLEAR' ),
 		context,
 	};
 };
@@ -38,7 +38,7 @@ export const clear = ( context ) => {
  */
 export const addNotice = ( payload ) => {
 	return {
-		type: /** @type {'ADD'} */ ( 'ADD' ),
+		type: /** @type {const} */ ( 'ADD' ),
 		payload,
 	};
 };
@@ -51,7 +51,7 @@ export const addNotice = ( payload ) => {
  */
 export const removeNotice = ( id ) => {
 	return {
-		type: /** @type {'DELETE'} */ ( 'DELETE' ),
+		type: /** @type {const} */ ( 'DELETE' ),
 		id,
 	};
 };
@@ -64,7 +64,7 @@ export const removeNotice = ( id ) => {
  */
 export const updateNotice = ( payload ) => {
 	return {
-		type: /** @type {'UPDATE'} */ ( 'UPDATE' ),
+		type: /** @type {const} */ ( 'UPDATE' ),
 		payload,
 	};
 };
@@ -77,7 +77,7 @@ export const updateNotice = ( payload ) => {
  */
 export const fetchAPI = ( path = '' ) => {
 	return {
-		type: /** @type {'FETCH'} */ ( 'FETCH' ),
+		type: /** @type {const} */ ( 'FETCH' ),
 		path,
 	};
 };

--- a/src/scripts/store/constants.js
+++ b/src/scripts/store/constants.js
@@ -1,27 +1,12 @@
 /**
- *  @member {string} NOTIFY_NAMESPACE WP Notification Feature namespace
+ * The WP Notification Feature default context.
  */
-export const NOTIFY_NAMESPACE = 'core/wp-notify';
+export const defaultContext = /** @type {const} */ 'adminbar';
 
 /**
- *  @member {string} API_PATH WP Notification Feature rest api path
+ * The WP Notification Feature default contexts
  */
-export const API_PATH = '/wp/v2/notifications/';
-
-/**
- *  @member {string} defaultContext WP Notification Feature default context
- */
-export const defaultContext = 'adminbar';
-
-/**
- *  @member {Object} context WP Notification Feature default contexts
- */
-export const contexts = [ defaultContext, 'dashboard' ];
-
-/**
- *  @member {number} The width of the notification hub
- */
-export const HUB_WIDTH = 320;
+export const contexts = /** @type {const} */ [ defaultContext, 'dashboard' ];
 
 /**
  *  @member {string} the url of the notifications settings page

--- a/src/scripts/store/controls.js
+++ b/src/scripts/store/controls.js
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { API_PATH } from './constants';
+import { API_PATH } from '../constants';
 
 /**
  * @typedef {import('./index').Notice} Notice
@@ -8,10 +8,18 @@ import { API_PATH } from './constants';
  * Fetches the wp-notify rest api endpoint for the specified endpoint
  *
  * @param {{path: string}} action The action to execute
- * @return {Promise<Notice>} The Promise with the results
+ * @return {Promise<Notice[]>} The Promise with the results
  */
 export const FETCH = ( action ) => {
 	return apiFetch( {
 		path: API_PATH + action.path,
-	} );
+	} ).then(
+		( /** @type {Object} */ notices ) =>
+			/** @type {Notice[]} */ (
+				notices.map( ( notice ) => ( {
+					...notice,
+					date: new Date( notice.date ),
+				} ) )
+			)
+	);
 };

--- a/src/scripts/store/index.js
+++ b/src/scripts/store/index.js
@@ -1,6 +1,6 @@
 import { createReduxStore, register } from '@wordpress/data';
 
-import { NOTIFY_NAMESPACE } from './constants';
+import { STORE_NAMESPACE } from '../constants';
 import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
@@ -57,7 +57,7 @@ import * as resolvers from './resolvers';
  * @typedef {Object} Notice The notification type.
  * @property {NoticeAction=} action       The optional action associated to the notification.
  * @property {string=}       context      The rendering context of the notification.
- * @property {number}        date         The datetime from which the notification was emitted.
+ * @property {Date}          date         The date from which the notification was emitted.
  * @property {string=}       dismissLabel The label of the dismiss action.
  * @property {boolean=}      dismissible  Predicate of whether the notification can be dismissed.
  * @property {NoticeIcon=}   icon         The optional icon.
@@ -79,7 +79,7 @@ import * as resolvers from './resolvers';
  * A Redux store that lets you read the state, dispatch actions and subscribe to changes.
  */
 const store = /** @type {NoticeStore} */ (
-	createReduxStore( NOTIFY_NAMESPACE, {
+	createReduxStore( STORE_NAMESPACE, {
 		reducer,
 		actions,
 		selectors,

--- a/src/scripts/utils/index.js
+++ b/src/scripts/utils/index.js
@@ -1,5 +1,4 @@
-import { NOTIFY_NAMESPACE } from '../store/constants';
-import { WEEK_IN_SECONDS } from '../components/NoticesArea';
+import { WEEK_IN_MILLISECONDS, STORE_NAMESPACE } from '../constants';
 import { dispatch } from '@wordpress/data';
 import { dateI18n } from '@wordpress/date';
 
@@ -26,13 +25,13 @@ export const delay = ( ms ) => new Promise( ( f ) => setTimeout( f, ms ) );
  */
 export const splitByDate = (
 	notifications,
-	limit = nowInSeconds() - WEEK_IN_SECONDS
+	limit = Date.now() - WEEK_IN_MILLISECONDS
 ) => {
 	return notifications.reduce(
-		( [ current, past ], item ) => {
-			return item.date >= limit
-				? [ [ ...current, item ], past ]
-				: [ current, [ ...past, item ] ];
+		( [ current, past ], notice ) => {
+			return notice.date.getTime() >= limit
+				? [ [ ...current, notice ], past ]
+				: [ current, [ ...past, notice ] ];
 		},
 		[ [], [] ]
 	);
@@ -61,12 +60,12 @@ export const nowInSeconds = () => {
 /**
  * Format the date from epoch to human-readable format.
  *
- * @param {number} date The date to convert in epoch format.
+ * @param {Date} date The date to convert in epoch format.
  *
  * @return {string} The date in human-readable format.
  */
 export const formatDate = ( date ) => {
-	return dateI18n( 'l jS F Y - h:i A', new Date( date ), true );
+	return dateI18n( 'l jS F Y - h:i A', date, true );
 };
 
 /**
@@ -75,5 +74,5 @@ export const formatDate = ( date ) => {
  * @param {string} context - The context of the notices. This is used to determine which notices to clear.
  */
 export const clearNotifyDrawer = ( context ) => {
-	dispatch( NOTIFY_NAMESPACE ).clear( context );
+	dispatch( STORE_NAMESPACE ).clear( context );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"target": "ES2017",
 		"module": "ES2015",
 		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true,
 
 		"allowJs": true,
 		"checkJs": true,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,12 +1,12 @@
 import {CurriedSelectorsOf} from '@wordpress/data/build-types/types'
 import {default as store, NoticeStore} from '../src/scripts/store'
-import {NOTIFY_NAMESPACE} from '../src/scripts/store/constants';
+import {STORE_NAMESPACE} from '../src/scripts/constants';
 
 declare global {
   interface Window { wp: { notify: any }; wp_notifications_data?: { settingsPage: string } }
 }
 
 declare module '@wordpress/data' {
-  function dispatch( key: typeof store | typeof NOTIFY_NAMESPACE ): typeof import( '../src/scripts/store/actions' );
-  function select( key: typeof store | typeof NOTIFY_NAMESPACE ): CurriedSelectorsOf< NoticeStore >;
+  function dispatch( key: typeof store | typeof STORE_NAMESPACE ): typeof import( '../src/scripts/store/actions' );
+  function select( key: typeof store | typeof STORE_NAMESPACE ): CurriedSelectorsOf< NoticeStore >;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Use the standard datetime strings used in the other REST API endpoints of WordPress in the fake api data.

Convert datetime strings into JS `Date`s at the time they are fetched from the API.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Using the standard datetimes makes the fake api more like the real thing.

**Additions**

- Move the some of the constants out of the store folder, they are used in many place in the project.
- Use `/** @type {const} */` type assertions, JSDoc style `as const`.