### PR TITLE
refactor: Drawer width logic

### DIFF
--- a/src/scripts/components/Drawer.js
+++ b/src/scripts/components/Drawer.js
@@ -1,4 +1,4 @@
-import { useState } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { Resizable } from 're-resizable';
@@ -6,11 +6,13 @@ import { Resizable } from 're-resizable';
 import { HUB_WIDTH } from '../constants';
 
 import { NoticesArea } from './NoticesArea';
+
 /**
- * This is a React component that renders a resizable drawer for displaying notifications.
- * The `Drawer` component is being returned, which is an `aside` element containing a `Resizable` component and a `NoticesArea` component.
- * The `Resizable` component allows the user to resize the width of the `Drawer` by dragging its left edge.
- * The `NoticesArea` component displays notifications in the `Drawer`.
+ * A resizable drawer React component for displaying notifications. The returned
+ * `Drawer` component is an `aside` element containing a `Resizable` component and
+ * `NoticesArea` component. The `Resizable` component provides UI controls to resize
+ * the width of the `Drawer` by dragging its left edge. The `NoticesArea` component
+ * displays notifications in the `Drawer`.
  *
  * @param {Object}               props
  * @param {(event: any) => void} props.focus    The `onFocus` event listener for the drawer.
@@ -24,6 +26,29 @@ export const Drawer = ( { focus, blur, instance } ) => {
 	useShortcut( 'wp-feature-notifications/close-drawer', () => blur );
 	const [ width, setWidth ] = useState( /** @type {number} */ ( HUB_WIDTH ) );
 
+	/**
+	 * Maybe resize the maximum width of the drawer if it exceeds the window size.
+	 *
+	 * @return {void}
+	 */
+	const handleWindowResize = useCallback( () => {
+		if ( window.innerWidth < width ) {
+			if ( window.innerWidth < HUB_WIDTH ) {
+				setWidth( HUB_WIDTH );
+			} else {
+				setWidth( window.innerWidth );
+			}
+		}
+	}, [ width ] );
+
+	useEffect( () => {
+		window.addEventListener( 'resize', handleWindowResize );
+
+		return () => {
+			window.removeEventListener( 'resize', handleWindowResize );
+		};
+	}, [ handleWindowResize ] );
+
 	return (
 		<aside
 			id="wp-notifications-hub"
@@ -34,8 +59,13 @@ export const Drawer = ( { focus, blur, instance } ) => {
 			<Resizable
 				size={ { width, height: '100%' } }
 				enable={ { left: true } }
-				onResizeStop={ ( e, direction, ref, d ) => {
-					setWidth( width + d.width );
+				onResizeStop={ ( _e, _direction, _ref, d ) => {
+					const currentWidth = width + d.width;
+					if ( currentWidth > window.innerWidth ) {
+						setWidth( window.innerWidth );
+					} else {
+						setWidth( width + d.width );
+					}
 				} }
 				minWidth={ HUB_WIDTH }
 			>

--- a/src/scripts/components/Drawer.js
+++ b/src/scripts/components/Drawer.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { Resizable } from 're-resizable';
@@ -26,29 +26,6 @@ export const Drawer = ( { focus, blur, instance } ) => {
 	useShortcut( 'wp-feature-notifications/close-drawer', () => blur );
 	const [ width, setWidth ] = useState( /** @type {number} */ ( HUB_WIDTH ) );
 
-	/**
-	 * Maybe resize the maximum width of the drawer if it exceeds the window size.
-	 *
-	 * @return {void}
-	 */
-	const handleWindowResize = useCallback( () => {
-		if ( window.innerWidth < width ) {
-			if ( window.innerWidth < HUB_WIDTH ) {
-				setWidth( HUB_WIDTH );
-			} else {
-				setWidth( window.innerWidth );
-			}
-		}
-	}, [ width ] );
-
-	useEffect( () => {
-		window.addEventListener( 'resize', handleWindowResize );
-
-		return () => {
-			window.removeEventListener( 'resize', handleWindowResize );
-		};
-	}, [ handleWindowResize ] );
-
 	return (
 		<aside
 			id="wp-notifications-hub"
@@ -60,13 +37,9 @@ export const Drawer = ( { focus, blur, instance } ) => {
 				size={ { width, height: '100%' } }
 				enable={ { left: true } }
 				onResizeStop={ ( _e, _direction, _ref, d ) => {
-					const currentWidth = width + d.width;
-					if ( currentWidth > window.innerWidth ) {
-						setWidth( window.innerWidth );
-					} else {
-						setWidth( width + d.width );
-					}
+					setWidth( width + d.width );
 				} }
+				maxWidth={ '100vw' }
 				minWidth={ HUB_WIDTH }
 			>
 				<div className={ 'hub-wrapper' }>

--- a/src/scripts/components/Drawer.js
+++ b/src/scripts/components/Drawer.js
@@ -22,7 +22,7 @@ export const Drawer = ( { focus, blur, instance } ) => {
 	 * Enables the shortcut to close the drawer with the escape key
 	 */
 	useShortcut( 'wp-feature-notifications/close-drawer', () => blur );
-	const [ width, setWidth ] = useState( HUB_WIDTH );
+	const [ width, setWidth ] = useState( /** @type {number} */ ( HUB_WIDTH ) );
 
 	return (
 		<aside


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Prevent the Drawer component from becoming larger than the window area.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Previously the Drawer could become larger than the window area by a user dragging the edge outside the window, or the window being resized smaller than the Drawer. Then the edge of the drawer was no longer in view and the drawer was stuck in a size too large to fit in the window.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added logic:

- To prevent the Drawer from being resized larger than the window when dragging the handle.
- To resize the Drawer on window resize if its width is smaller than the window. Though it will not go lower than minimum `HUB_WIDTH`.