### PR TITLE
build: add eslint import order rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,26 @@ module.exports = {
 		project: [ './tsconfig.json', 'tsconfig.eslint.json' ],
 	},
 	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	rules: {
+		'import/order': [
+			'error',
+			{
+				alphabetize: {
+					order: 'asc',
+					caseInsensitive: true,
+				},
+				'newlines-between': 'always',
+				groups: [ 'builtin', 'external', 'parent', 'sibling', 'index' ],
+				pathGroups: [
+					{
+						pattern: '@wordpress/**',
+						group: 'external',
+					},
+				],
+				pathGroupsExcludedImportTypes: [ 'builtin' ],
+			},
+		],
+	},
 	settings: {
 		'import/parsers': {
 			'@typescript-eslint/parser': [ '.js', '.jsx', '.ts', '.tsx' ],

--- a/src/scripts/components/Drawer.js
+++ b/src/scripts/components/Drawer.js
@@ -1,10 +1,11 @@
-import { __ } from '@wordpress/i18n';
-import { NoticesArea } from './NoticesArea';
-import { Resizable } from 're-resizable';
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { Resizable } from 're-resizable';
+
 import { HUB_WIDTH } from '../constants';
 
+import { NoticesArea } from './NoticesArea';
 /**
  * This is a React component that renders a resizable drawer for displaying notifications.
  * The `Drawer` component is being returned, which is an `aside` element containing a `Resizable` component and a `NoticesArea` component.

--- a/src/scripts/components/Notice.js
+++ b/src/scripts/components/Notice.js
@@ -4,19 +4,17 @@
  * https://github.com/WordPress/wp-feature-notifications/issues/37#issuecomment-896080025
  */
 
-// Register components
-import { NoticeIcon } from './NoticeImage';
-import { NoticeActions } from './NoticeAction';
-
-// Import utilities
-// @ts-ignore
-import classnames from 'classnames';
-import { STORE_NAMESPACE } from '../constants';
-import { purify } from '../utils/sanitization';
-import { defaultContext } from '../store/constants';
 import { dispatch } from '@wordpress/data';
-import { NoticeMeta } from './NoticeMeta';
+import classnames from 'classnames';
+
+import { STORE_NAMESPACE } from '../constants';
+import { defaultContext } from '../store/constants';
 import { delay } from '../utils';
+import { purify } from '../utils/sanitization';
+
+import { NoticeActions } from './NoticeAction';
+import { NoticeIcon } from './NoticeImage';
+import { NoticeMeta } from './NoticeMeta';
 
 /**
  * @typedef {import('../store').Notice} Notice

--- a/src/scripts/components/NoticeAction.js
+++ b/src/scripts/components/NoticeAction.js
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
 import { defaultContext } from '../store/constants';
 
 /**

--- a/src/scripts/components/NoticeHubFooter.js
+++ b/src/scripts/components/NoticeHubFooter.js
@@ -1,6 +1,7 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { cog } from '@wordpress/icons';
-import { Button } from '@wordpress/components';
+
 import { settingsPageUrl } from '../store/constants';
 
 /**

--- a/src/scripts/components/NoticeHubSectionHeader.js
+++ b/src/scripts/components/NoticeHubSectionHeader.js
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
+
 import { clearNotifyDrawer } from '../utils/';
 
 /**

--- a/src/scripts/components/NoticeImage.js
+++ b/src/scripts/components/NoticeImage.js
@@ -1,9 +1,10 @@
 // @ts-ignore
-import wpLogo from '../../images/WordPressLogo.svg';
 import * as classNames from 'classnames';
+
+import wpLogo from '../../images/WordPressLogo.svg';
 import { defaultContext } from '../store/constants';
-import { purify } from '../utils/sanitization';
 import { isDashiconsIcon, isSvgIcon } from '../utils/guards';
+import { purify } from '../utils/sanitization';
 
 /**
  * @typedef {import('../store').NoticeIcon} NoticeIcon

--- a/src/scripts/components/NoticesArea.js
+++ b/src/scripts/components/NoticesArea.js
@@ -1,13 +1,14 @@
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
+import store from '../store';
 import { defaultContext } from '../store/constants';
+import { splitByDate } from '../utils/';
+
 import { NoticeEmpty } from './NoticeEmpty';
+import { NoticeHubFooter } from './NoticeHubFooter';
 import { NoticeHubSectionHeader } from './NoticeHubSectionHeader';
 import { NoticesLoop } from './NoticesLoop';
-import { splitByDate } from '../utils/';
-import { NoticeHubFooter } from './NoticeHubFooter';
-import store from '../store';
 
 export const WEEK_IN_SECONDS = 3600 * 24 * 7;
 

--- a/src/scripts/components/NotificationHub.js
+++ b/src/scripts/components/NotificationHub.js
@@ -1,13 +1,14 @@
-import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import {
 	ShortcutProvider,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
-import { useDispatch } from '@wordpress/data';
+import * as classNames from 'classnames';
+
 import { Drawer } from './Drawer';
 import { NotificationHubIcon } from './NotificationHubIcon';
-import * as classNames from 'classnames';
 
 /**
  * The notification hub component.

--- a/src/scripts/demo/index.js
+++ b/src/scripts/demo/index.js
@@ -2,8 +2,9 @@
  * On load listen for metabox events like submit, clear etc
  */
 import { dispatch } from '@wordpress/data';
-import { STORE_NAMESPACE } from '../constants';
 import { __ } from '@wordpress/i18n';
+
+import { STORE_NAMESPACE } from '../constants';
 
 /**
  *  @typedef {import('../store').Notice} Notice

--- a/src/scripts/store/controls.js
+++ b/src/scripts/store/controls.js
@@ -1,4 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
+
 import { API_PATH } from '../constants';
 
 /**

--- a/src/scripts/store/index.js
+++ b/src/scripts/store/index.js
@@ -1,11 +1,12 @@
 import { createReduxStore, register } from '@wordpress/data';
 
 import { STORE_NAMESPACE } from '../constants';
-import reducer from './reducer';
+
 import * as actions from './actions';
-import * as selectors from './selectors';
 import * as controls from './controls';
+import reducer from './reducer';
 import * as resolvers from './resolvers';
+import * as selectors from './selectors';
 
 /**
  *

--- a/src/scripts/store/selectors.js
+++ b/src/scripts/store/selectors.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+
 import { findContext } from './utils';
 
 /**

--- a/src/scripts/utils/index.js
+++ b/src/scripts/utils/index.js
@@ -1,6 +1,7 @@
-import { WEEK_IN_MILLISECONDS, STORE_NAMESPACE } from '../constants';
 import { dispatch } from '@wordpress/data';
 import { dateI18n } from '@wordpress/date';
+
+import { WEEK_IN_MILLISECONDS, STORE_NAMESPACE } from '../constants';
 
 /**
  * @typedef {import('../store').Notice} Notice

--- a/src/scripts/utils/init.js
+++ b/src/scripts/utils/init.js
@@ -1,4 +1,5 @@
 import { createRoot } from '@wordpress/element';
+
 import { NoticesArea } from '../components/NoticesArea';
 import { NotificationHub } from '../components/NotificationHub';
 


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add ESLint rules to organize the order of imports in JavaScript files.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

It helps keep things organized and easier to see at a glance if a decency is from WordPress, external or internal.