### PR TITLE
fix: rest api namespace

### DIFF
--- a/includes/restapi/class-notification-controller.php
+++ b/includes/restapi/class-notification-controller.php
@@ -23,7 +23,7 @@ class Notification_Controller extends WP_REST_Controller {
 	 *
 	 * @type string
 	 */
-	const NAMESPACE = 'wp/v2';
+	const NAMESPACE = 'wp-notifications/v1';
 
 	/**
 	 * Base for notification REST routes.

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -6,7 +6,8 @@ export const STORE_NAMESPACE = /** @type {const} */ 'core/wp-notifications';
 /**
  * API_PATH WP Notification Feature rest api path.
  */
-export const API_PATH = /** @type {const} */ '/wp/v2/notifications/';
+export const API_PATH =
+	/** @type {const} */ '/wp-notifications/v1/notifications/';
 
 /**
  * The width of the notification hub.


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Move the REST API namespace off the one reserved for WordPress.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Until this is merged into core, it should use it's own namespace.

Fixes #194