### PR TITLE
fix: remove SMS and App from demo settings options

### DIFF
--- a/includes/demo.php
+++ b/includes/demo.php
@@ -137,8 +137,6 @@ function render_admin_options_page() {    ?>
 				'show'   => __( 'Show in:' ),
 				'admin'  => __( 'Admin' ),
 				'email'  => __( 'Email' ),
-				'sms'    => __( 'Sms' ),
-				'app'    => __( 'App' ),
 			);
 		}
 
@@ -182,8 +180,6 @@ function render_admin_options_page() {    ?>
 					'show'   => '',
 					'admin'  => '<input type="checkbox" id="cb-admin-' . $i . '" />',
 					'email'  => '<input type="checkbox" id="cb-email-' . $i . '" />',
-					'sms'    => '<input type="checkbox" id="cb-sms-' . $i . '" />',
-					'app'    => '<input type="checkbox" id="cb-app-' . $i . '" />',
 				);
 			}
 			return $data;
@@ -196,8 +192,6 @@ function render_admin_options_page() {    ?>
 				case 'show':
 				case 'admin':
 				case 'email':
-				case 'sms':
-				case 'app':
 					return $item[ $column_name ];
 
 				default:


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove SMS and App from the demo settings page.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Multiple sources of feedback confirmed we shouldn't attempt supporting those opinions, especially in the initial phases of the project. 

We were aware of this, and those were put in more as an aspirational goal. Though it's caused some confusion for people demoing the plugin.

Fixes  #106
Addresses a concern raised in WordPress Slack by @paaljoachim and visualized in #281