### PR TITLE
feature(mvp): Stage 2 - add initial model classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
 	"name": "wordpress/wp-feature-notifications",
 	"description": "Notifications for WordPress (Feature Plugin)",
 	"type": "wordpress-plugin",
+	"require": {
+		"ext-json": "*"
+	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.6",
 		"yoast/phpunit-polyfills": "1.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52ca58825299b7ea26c4b7798bdb5730",
+    "content-hash": "e9a58530f931316fe8917362126f3ac4",
     "packages": [],
     "packages-dev": [
         {
@@ -1212,16 +1212,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.6",
+            "version": "9.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
                 "shasum": ""
             },
             "require": {
@@ -1295,7 +1295,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
             },
             "funding": [
                 {
@@ -1311,7 +1311,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T11:43:46+00:00"
+            "time": "2023-04-14T08:58:40+00:00"
         },
         {
             "name": "psr/cache",
@@ -4136,7 +4136,9 @@
     "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-json": "*"
+    },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"

--- a/includes/helper/class-serde.php
+++ b/includes/helper/class-serde.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Notifications API:Serde class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Helper;
+
+use DateTime;
+
+/**
+ * Class Serde
+ *
+ * SERialization and DEserialization helper static class.
+ */
+class Serde {
+
+	/**
+	 * Maybe serialize a DateTime as an ISO 8601 date string.
+	 *
+	 * @param DateTime|null $date The possible DateTime object to serialize.
+	 *
+	 * @return string|null Maybe an ISO 8601 date string.
+	 */
+	public static function maybe_serialize_json_date( $date ) {
+		if ( null === $date ) {
+			return null;
+		}
+
+		return $date->format( DateTime::ATOM );
+	}
+
+	/**
+	 * Maybe deserialize a datetime string in MySQL format.
+	 *
+	 * @param string|DateTime|null $date The possible MySQL datetime to deserialize.
+	 *
+	 * @return DateTime|null Maybe a DateTime object.
+	 */
+	public static function maybe_deserialize_mysql_date( $date ) {
+		if ( null === $date ) {
+			return null;
+		}
+
+		if ( $date instanceof DateTime ) {
+			return $date;
+		}
+
+		if ( is_string( $date ) ) {
+			$date = DateTime::createFromFormat( 'Y-m-d H:i:s', $date );
+
+			if ( false === $date ) {
+				$date = null;
+			}
+		}
+
+		return $date;
+	}
+}

--- a/includes/model/class-channel.php
+++ b/includes/model/class-channel.php
@@ -81,7 +81,7 @@ class Channel implements JsonSerializable {
 	/**
 	 * Specifies data which should be serialized to JSON.
 	 *
-	 * @return mixed Data which can be serialized by json_encode, which is a
+	 * @return array Data which can be serialized by json_encode, which is a
 	 *               value of any type other than a resource.
 	 */
 	public function jsonSerialize() {

--- a/includes/model/class-channel.php
+++ b/includes/model/class-channel.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Notifications API:Channel class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Model;
+
+use JsonSerializable;
+
+/**
+ * Class representing a notification channel.
+ *
+ * @see \WP\Notifications\register_channel()
+ */
+class Channel implements JsonSerializable {
+
+	// Required properties
+
+	/**
+	 * Name, including namespace, of the channel.
+	 */
+	protected ?string $name;
+
+	/**
+	 * Human-readable label of the channel.
+	 */
+	protected ?string $title;
+
+	// Optional properties
+
+	/**
+	 * Display context of the channel.
+	 */
+	protected ?string $context;
+
+	/**
+	 * Detailed description of the channel.
+	 */
+	protected ?string $description;
+
+	/**
+	 * Icon of the channel.
+	 */
+	protected ?string $icon;
+
+	/**
+	 * Constructor.
+	 *
+	 * Instantiates a Channel object.
+	 *
+	 * @see register_channel()
+	 *
+	 * @param ?string $name        Name, including namespace, of the channel.
+	 * @param ?string $title       Human-readable label of the channel.
+	 * @param ?string $context     Optional default display context of the channel.
+	 * @param ?string $description Optional detailed description of the channel.
+	 * @param ?string $icon        Optional icon of the channel.
+	 *
+	 */
+	public function __construct(
+		$name = null,
+		$title = null,
+		$context = null,
+		$description = null,
+		$icon = null
+		) {
+		// Required properties
+
+		$this->name  = $name;
+		$this->title = $title;
+
+		// Optional properties
+
+		$this->context     = $context;
+		$this->icon        = $icon;
+		$this->description = $description;
+	}
+
+	/**
+	 * Specifies data which should be serialized to JSON.
+	 *
+	 * @return mixed Data which can be serialized by json_encode, which is a
+	 *               value of any type other than a resource.
+	 */
+	public function jsonSerialize() {
+		return array(
+			'context'     => $this->context,
+			'description' => $this->description,
+			'icon'        => $this->icon,
+			'name'        => $this->name,
+			'title'       => $this->title,
+		);
+	}
+
+	/**
+	 * Get the namespaced name.
+	 *
+	 * @return ?string The namespaced name of the channel.
+	 */
+	public function get_name(): ?string {
+		return $this->name;
+	}
+
+	/**
+	 * Get the human-readable label.
+	 *
+	 * @return ?string The title of the channel.
+	 */
+	public function get_title(): ?string {
+		return $this->title;
+	}
+
+	/**
+	 * Get the default display context.
+	 *
+	 * @return ?string The context of the channel.
+	 */
+	public function get_context(): ?string {
+		return $this->context;
+	}
+
+	/**
+	 * Get the detailed description.
+	 *
+	 * @return ?string The description of the channel.
+	 */
+	public function get_description(): ?string {
+		return $this->description;
+	}
+
+	/**
+	 * Get the icon.
+	 *
+	 * @return ?string The icon of the channel.
+	 */
+	public function get_icon(): ?string {
+		return $this->icon;
+	}
+}

--- a/includes/model/class-message.php
+++ b/includes/model/class-message.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Notifications API:Message class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Model;
+
+use DateTime;
+use JsonSerializable;
+use WP\Notifications\Helper;
+
+/**
+ * Class representing a message.
+ */
+class Message implements JsonSerializable {
+
+	/**
+	 * The accepted keys of the message metadata.
+	 */
+	static protected $meta_keys = array(
+		'accept_label',
+		'accept_link',
+		'channel_title',
+		'dismiss_label',
+		'expires_at',
+		'icon',
+		'is_dismissible',
+		'severity',
+	);
+
+	// Required properties
+
+	/**
+	 * Text content of the message.
+	 */
+	protected ?string $message;
+
+	// Optional properties
+
+	/**
+	 * Label of the accept action.
+	 */
+	protected ?string $accept_label;
+
+	/**
+	 * URL of the accept action.
+	 */
+	protected ?string $accept_link;
+
+	/**
+	 * Human-readable title of the channel of which the message was emitted.
+	 */
+	protected ?string $channel_title;
+
+	/**
+	 * Datetime at which a message was created.
+	 */
+	protected ?DateTime $created_at;
+
+	/**
+	 * Label of the dismiss action.
+	 */
+	protected ?string $dismiss_label;
+
+	/**
+	 * Datetime at which a message expires.
+	 */
+	protected ?DateTime $expires_at;
+
+	/**
+	 * Icon of the message.
+	 */
+	protected ?string $icon;
+
+	/**
+	 * Database primary key value.
+	 */
+	protected ?int $id;
+
+	/**
+	 * Whether the notice can be dismissed.
+	 */
+	protected ?bool $is_dismissible;
+
+	/**
+	 * Severity of the message.
+	 */
+	protected ?string $severity;
+
+	/**
+	 * Human-readable message label.
+	 */
+	protected ?string $title;
+
+	/**
+	 * Constructor.
+	 *
+	 * Instantiates a Message object.
+	 *
+	 * @param ?string    $message        Text content of the message.
+	 * @param ?string    $accept_label   Optional label of the action.
+	 * @param ?string    $accept_link    Optional URL of the action.
+	 * @param ?string    $channel_title  Optional human-readable title of the channel
+	 *                                   the message was emitted from.
+	 * @param ?DateTime  $created_at     Optional datetime at which the message was
+	 *                                   created. Default `'null'`
+	 * @param ?string    $dismiss_label  Optional label of the dismiss action.
+	 * @param ?DateTime  $expires_at     Optional datetime at which a message expires.
+	 *                                   Default `'null'`
+	 * @param ?string    $icon           Optional icon of the message. Default `null`
+	 * @param ?int       $id             Optional database ID of the message. Default `null`
+	 * @param ?bool      $is_dismissible Optional boolean of whether the notice can be
+	 *                                   dismissed. Default `true`
+	 * @param ?string    $severity       Optional severity of the message. Default `null`
+	 * @param ?string    $title          Optional human-readable label of the message.
+	 */
+	public function __construct(
+		$message = null,
+		$accept_label = null,
+		$accept_link = null,
+		$channel_title = null,
+		$created_at = null,
+		$dismiss_label = null,
+		$expires_at = null,
+		$icon = null,
+		$id = null,
+		$is_dismissible = true,
+		$severity = null,
+		$title = null
+	) {
+		// Required properties
+
+		$this->message = $message;
+
+		// Optional properties
+
+		$this->accept_label   = $accept_label;
+		$this->accept_link    = $accept_link;
+		$this->channel_title  = $channel_title;
+		$this->created_at     = $created_at;
+		$this->dismiss_label  = $dismiss_label;
+		$this->expires_at     = $expires_at;
+		$this->icon           = $icon;
+		$this->id             = $id;
+		$this->is_dismissible = $is_dismissible;
+		$this->severity       = $severity;
+		$this->title          = $title;
+	}
+
+	/**
+	 * Specifies data which should be serialized to JSON.
+	 *
+	 * @return mixed Data which can be serialized by json_encode, which is a
+	 *               value of any type other than a resource.
+	 */
+	public function jsonSerialize() {
+		return array_merge(
+			$this->collect_meta(),
+			array(
+				'created_at' => Helper\Serde::maybe_serialize_json_date( $this->created_at ),
+				'expires_at' => Helper\Serde::maybe_serialize_json_date( $this->expires_at ),
+				'id'         => $this->id,
+				'message'    => $this->message,
+				'title'      => $this->title,
+			)
+		);
+	}
+
+	/**
+	 * Returns the JSON representation of the message metadata, or `false` if encoding fails.
+	 *
+	 * @return string|false
+	 */
+	public function encode_meta() {
+		return json_encode( $this->collect_meta() );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return ?string The title of the message.
+	 */
+	public function get_title(): ?string {
+		return $this->title;
+	}
+
+	/**
+	 * Get the content.
+	 *
+	 * @return ?string The content of the message.
+	 */
+	public function get_message(): ?string {
+		return $this->message;
+	}
+
+	// Optional property getters
+
+	/**
+	 * Get the accept action label.
+	 *
+	 * @return ?string The accept action label of message.
+	 */
+	public function get_accept_label(): ?string {
+		return $this->accept_label;
+	}
+
+	/**
+	 * Get the accept action link.
+	 *
+	 * @return ?string The accept action link of the message.
+	 */
+	public function get_accept_link(): ?string {
+		return $this->accept_link;
+	}
+
+	/**
+	 * Get the created at datetime.
+	 *
+	 * @return ?DateTime The datetime at which the message was created.
+	 */
+	public function get_created_at(): ?DateTime {
+		return $this->created_at;
+	}
+
+	/**
+	 * Get whether the message is dismissible.
+	 *
+	 * @return ?bool The is dismissible property of the message.
+	 */
+	public function get_is_dismissible(): ?bool {
+		return $this->is_dismissible;
+	}
+
+	/**
+	 * Get the dismiss label.
+	 *
+	 * @return ?string The dismiss label of the message.
+	 */
+	public function get_dismiss_label(): ?string {
+		return $this->dismiss_label;
+	}
+
+	/**
+	 * Get the expires at datetime.
+	 *
+	 * @return ?DateTime The expires at datetime of the message.
+	 */
+	public function get_expires_at(): ?DateTime {
+		return $this->expires_at;
+	}
+
+	/**
+	 * Get the icon.
+	 *
+	 * @return ?string The icon of the message.
+	 */
+	public function get_icon(): ?string {
+		return $this->icon;
+	}
+
+	/**
+	 * Get the database ID.
+	 *
+	 * @return ?int The database ID of the message.
+	 */
+	public function get_id(): ?int {
+		return $this->id;
+	}
+
+	/**
+	 * Get the severity.
+	 *
+	 * @return ?string The severity of the message.
+	 */
+	public function get_severity(): ?string {
+		return $this->severity;
+	}
+
+	/**
+	 * Check whether the content of the message is valid.
+	 */
+	protected function validate_message() {
+		if ( ! is_string( $this->message ) ) {
+			return false;
+		}
+
+		$length = mb_strlen( $this->message, '8bit' );
+
+		if ( $length > 255 ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Collect the message metadata values which are non null.
+	 *
+	 * @return mixed The metadata of the message.
+	 */
+	protected function collect_meta() {
+		$metadata = array();
+
+		foreach ( self::$meta_keys as $key ) {
+			if ( null !== $this->{ $key } ) {
+				$metadata[ $key ] = $this->{ $key };
+			}
+		}
+
+		return $metadata;
+	}
+}

--- a/includes/model/class-message.php
+++ b/includes/model/class-message.php
@@ -152,7 +152,7 @@ class Message implements JsonSerializable {
 	/**
 	 * Specifies data which should be serialized to JSON.
 	 *
-	 * @return mixed Data which can be serialized by json_encode, which is a
+	 * @return array Data which can be serialized by json_encode, which is a
 	 *               value of any type other than a resource.
 	 */
 	public function jsonSerialize() {
@@ -298,7 +298,7 @@ class Message implements JsonSerializable {
 	/**
 	 * Collect the message metadata values which are non null.
 	 *
-	 * @return mixed The metadata of the message.
+	 * @return array The metadata of the message.
 	 */
 	protected function collect_meta() {
 		$metadata = array();

--- a/includes/model/class-notification.php
+++ b/includes/model/class-notification.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Notifications API:Notification class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Model;
+
+use DateTime;
+use JsonSerializable;
+use WP\Notifications\Helper;
+
+/**
+ * Class representing a notification.
+ */
+class Notification implements JsonSerializable {
+
+	/**
+	 * Channel name, including namespace, the notification belongs to.
+	 */
+	protected ?string $channel_name;
+
+	/**
+	 * Display context of the notification.
+	 */
+	protected ?string $context;
+
+	/**
+	 * Datetime at which the notification was created.
+	 */
+	protected ?DateTime $created_at;
+
+	/**
+	 * Datetime at which the notification was dismissed.
+	 */
+	protected ?DateTime $dismissed_at;
+
+	/**
+	 * Datetime at which the notification was first displayed to the user.
+	 *
+	 * Intended to facility polling for new notifications from the client.
+	 */
+	protected ?DateTime $displayed_at;
+
+	/**
+	 * Datetime at which the notification expires.
+	 *
+	 * Intended to allow notification emitters to specify when a notification can be automatically
+	 * disposed of in UTC time.
+	 */
+	protected ?DateTime $expires_at;
+
+	/**
+	 * Database ID of the message related to the notification.
+	 */
+	protected ?int $message_id;
+
+	/**
+	 * Database ID of the user the notification belongs to.
+	 */
+	protected ?int $user_id;
+
+	/**
+	 * Constructor.
+	 *
+	 * Instantiates a Notice object.
+	 *
+	 * @param ?string    $channel_name Channel name, including namespace, the notification
+	 *                                 was emitted from.
+	 * @param ?int       $message_id   ID of the message related to the notification.
+	 * @param ?int       $user_id      ID of the user the notification belongs to.
+	 * @param ?string    $context      Optional display context of the notification.
+	 *                                 Default `'adminbar'`
+	 * @param ?DateTime  $created_at   Optional datetime at which the notification was created.
+	 * @param ?DateTime  $dismissed_at Optional datetime  t which the notification was dismissed.
+	 * @param ?DateTime  $displayed_at Optional datetime at which the notification was first displayed.
+	 * @param ?DateTime  $expires_at   Optional datetime at which the notification expires.
+	 */
+	public function __construct(
+		$channel_name = null,
+		$message_id = null,
+		$user_id = null,
+		$context = 'adminbar',
+		$created_at = null,
+		$dismissed_at = null,
+		$displayed_at = null,
+		$expires_at = null
+	) {
+		// Required properties
+
+		$this->channel_name = $channel_name;
+		$this->message_id   = $message_id;
+		$this->user_id      = $user_id;
+
+		// Optional properties
+
+		$this->context      = $context;
+		$this->created_at   = $created_at;
+		$this->dismissed_at = $dismissed_at;
+		$this->displayed_at = $displayed_at;
+		$this->expires_at   = $expires_at;
+	}
+
+	/**
+	 * Specifies data which should be serialized to JSON.
+	 *
+	 * @return mixed Data which can be serialized by json_encode, which is a
+	 *               value of any type other than a resource.
+	 */
+	public function jsonSerialize() {
+		return array(
+			'channel_name' => $this->channel_name,
+			'context'      => $this->context,
+			'created_at'   => Helper\Serde::maybe_serialize_json_date( $this->created_at ),
+			'dismissed_at' => Helper\Serde::maybe_serialize_json_date( $this->dismissed_at ),
+			'displayed_at' => Helper\Serde::maybe_serialize_json_date( $this->displayed_at ),
+			'expires_at'   => Helper\Serde::maybe_serialize_json_date( $this->expires_at ),
+			'message_id'   => $this->message_id,
+			'user_id'      => $this->user_id,
+		);
+	}
+
+	/**
+	 * Get the namespaced channel name.
+	 *
+	 * @return ?string The namespaced channel name of the notification.
+	 */
+	public function get_channel_name(): ?string {
+		return $this->channel_name;
+	}
+
+	/**
+	 * Get the display context.
+	 *
+	 * @return ?string The display context of the notification.
+	 */
+	public function get_context(): ?string {
+		return $this->context;
+	}
+
+	/**
+	 * Get the created at datetime.
+	 *
+	 * @return ?DateTime The datetime at which the notification was created.
+	 */
+	public function get_created_at(): ?DateTime {
+		return $this->created_at;
+	}
+
+	/**
+	 * Get the dismissed at datetime.
+	 *
+	 * @return ?DateTime The datetime at which the notification was dismissed.
+	 */
+	public function get_dismissed_at(): ?DateTime {
+		return $this->dismissed_at;
+	}
+
+	/**
+	 * Get the displayed at datetime.
+	 *
+	 * @return ?DateTime The datetime at which the notification was first displayed.
+	 */
+	public function get_displayed_at(): ?DateTime {
+		return $this->displayed_at;
+	}
+
+	/**
+	 * Get the expires at datetime.
+	 *
+	 * @return ?DateTime The datetime at which the notification expires.
+	 */
+	public function get_expires_at(): ?DateTime {
+		return $this->expires_at;
+	}
+
+	/**
+	 * Get the message ID.
+	 *
+	 * @return ?int The database ID of the message related to the notification.
+	 */
+	public function get_message_id(): ?int {
+		return $this->message_id;
+	}
+
+	/**
+	 * Get the user ID.
+	 *
+	 * @return ?int The database ID of the user the notification belongs to.
+	 */
+	public function get_user_id(): ?int {
+		return $this->user_id;
+	}
+}

--- a/includes/model/class-notification.php
+++ b/includes/model/class-notification.php
@@ -105,7 +105,7 @@ class Notification implements JsonSerializable {
 	/**
 	 * Specifies data which should be serialized to JSON.
 	 *
-	 * @return mixed Data which can be serialized by json_encode, which is a
+	 * @return array Data which can be serialized by json_encode, which is a
 	 *               value of any type other than a resource.
 	 */
 	public function jsonSerialize() {

--- a/includes/model/class-subscription.php
+++ b/includes/model/class-subscription.php
@@ -76,7 +76,7 @@ class Subscription implements JsonSerializable {
 	/**
 	 * Specifies data which should be serialized to JSON.
 	 *
-	 * @return mixed Data which can be serialized by json_encode, which is a
+	 * @return array Data which can be serialized by json_encode, which is a
 	 *               value of any type other than a resource.
 	 */
 	public function jsonSerialize() {

--- a/includes/model/class-subscription.php
+++ b/includes/model/class-subscription.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Notifications API:Subscription class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Model;
+
+use DateTime;
+use JsonSerializable;
+use WP\Notifications\Helper;
+
+/**
+ * Class representing a notification channel subscription.
+ */
+class Subscription implements JsonSerializable {
+
+	/**
+	 * Channel name, including namespace, the subscription belongs to.
+	 *
+	 * Used to relate a user and notification channel at the time of notice emission.
+	 */
+	protected ?string $channel_name;
+
+	/**
+	 * Datetime at which the subscription was created.
+	 */
+	protected ?DateTime $created_at;
+
+	/**
+	 * ID of the user the subscription belongs to.
+	 */
+	protected ?int $user_id;
+
+	// Optional properties
+
+	/**
+	 * Snoozed until option of the subscription.
+	 *
+	 * Intended to allow users a quick method to disable a channel subscription for
+	 * a set amount of time.
+	 */
+	protected ?DateTime $snoozed_until;
+
+	/**
+	 * Constructor.
+	 *
+	 * Instantiates a Subscription object.
+	 *
+	 * @param ?string   $channel_name  Channel name, including namespace, the
+	 *                                 subscription belongs to.
+	 * @param ?int      $user_id       ID of the user the subscription belongs to.
+	 * @param ?DateTime $created_at    Optional datetime at which the subscription
+	 *                                 was created.
+	 * @param ?DateTime $snoozed_until Optional snoozed until datetime of the
+	 *                                 subscription.
+	 */
+	public function __construct(
+		$channel_name = null,
+		$user_id = null,
+		$created_at = null,
+		$snoozed_until = null
+	) {
+		// Required properties
+
+		$this->channel_name = $channel_name;
+		$this->user_id      = $user_id;
+
+		// Optional properties
+
+		$this->created_at    = $created_at;
+		$this->snoozed_until = $snoozed_until;
+	}
+
+	/**
+	 * Specifies data which should be serialized to JSON.
+	 *
+	 * @return mixed Data which can be serialized by json_encode, which is a
+	 *               value of any type other than a resource.
+	 */
+	public function jsonSerialize() {
+		return array(
+			'channel_name'  => $this->channel_name,
+			'created_at'    => Helper\Serde::maybe_serialize_json_date( $this->created_at ),
+			'snoozed_until' => Helper\Serde::maybe_serialize_json_date( $this->snoozed_until ),
+			'user_id'       => $this->user_id,
+		);
+	}
+
+	/**
+	 * Get the namespaced channel name.
+	 *
+	 * @return ?string The namespaced channel name of the subscription.
+	 */
+	public function get_channel_name(): ?string {
+		return $this->channel_name;
+	}
+
+	/**
+	 * Get the created at datetime.
+	 *
+	 * @return ?DateTime The datetime at which the subscription was created.
+	 */
+	public function get_created_at(): ?DateTime {
+		return $this->created_at;
+	}
+
+	/**
+	 * Get the snoozed until option.
+	 *
+	 * @return ?DateTime The snoozed until option of the subscription.
+	 */
+	public function get_snoozed_until(): ?DateTime {
+		return $this->snoozed_until;
+	}
+
+	/**
+	 * Get the user ID.
+	 *
+	 * @return ?int The user ID of the subscription.
+	 */
+	public function get_user_id(): ?int {
+		return $this->user_id;
+	}
+
+}

--- a/tests/phpunit/tests/model/test-model-channel.php
+++ b/tests/phpunit/tests/model/test-model-channel.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WP\Notifications\Test;
+
+use WP_UnitTestCase;
+use WP\Notifications\Model;
+
+class Test_Model_Channel extends WP_UnitTestCase {
+
+	/**
+	 * Test channel model.
+	 */
+	private ?Model\Channel $model = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->model = new Model\Channel(
+			'core/test',
+			'Test channel',
+			'test',
+			'A test case channel',
+			'WordPress'
+		);
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->model = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should be JSON serializable.
+	 */
+	public function test_json_serializable() {
+		$actual   = json_encode( $this->model, JSON_PRETTY_PRINT );
+		$expected = '{
+    "context": "test",
+    "description": "A test case channel",
+    "icon": "WordPress",
+    "name": "core\/test",
+    "title": "Test channel"
+}';
+		$this->assertEquals( $actual, $expected );
+	}
+}

--- a/tests/phpunit/tests/model/test-model-message.php
+++ b/tests/phpunit/tests/model/test-model-message.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace WP\Notifications\Test;
+
+use WP_UnitTestCase;
+use WP\Notifications\Model;
+
+class Test_Model_Message extends WP_UnitTestCase {
+
+	/**
+	 * Test message model.
+	 */
+	private ?Model\Message $model = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->model = new Model\Message(
+			'Testing, testings... 1, 2, 3... testing',
+			'Ok',
+			null,
+			'Test channel',
+			null,
+			'Nope',
+			null,
+			'hammer',
+			null,
+			true,
+			'warning',
+			'Message model test'
+		);
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->model = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should be JSON serializable.
+	 */
+	public function test_json_serializable() {
+		$actual   = json_encode( $this->model, JSON_PRETTY_PRINT );
+		$expected = '{
+    "accept_label": "Ok",
+    "channel_title": "Test channel",
+    "dismiss_label": "Nope",
+    "icon": "hammer",
+    "is_dismissible": true,
+    "severity": "warning",
+    "created_at": null,
+    "expires_at": null,
+    "id": null,
+    "message": "Testing, testings... 1, 2, 3... testing",
+    "title": "Message model test"
+}';
+		$this->assertEquals( $actual, $expected );
+	}
+}

--- a/tests/phpunit/tests/model/test-model-notification.php
+++ b/tests/phpunit/tests/model/test-model-notification.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace WP\Notifications\Test;
+
+use DateTime;
+use WP_UnitTestCase;
+use WP\Notifications\Model;
+
+class Test_Model_Notification extends WP_UnitTestCase {
+
+	/**
+	 * Test message model.
+	 */
+	private ?Model\Notification $model = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->model = new Model\Notification(
+			'core/test',
+			1,
+			1,
+			'adminbar',
+			null,
+			null,
+			null,
+			new DateTime( '2023-12-31' )
+		);
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->model = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should be JSON serializable.
+	 */
+	public function test_json_serializable() {
+		$actual   = json_encode( $this->model, JSON_PRETTY_PRINT );
+		$expected = '{
+    "channel_name": "core\/test",
+    "context": "adminbar",
+    "created_at": null,
+    "dismissed_at": null,
+    "displayed_at": null,
+    "expires_at": "2023-12-31T00:00:00+00:00",
+    "message_id": 1,
+    "user_id": 1
+}';
+		$this->assertEquals( $actual, $expected );
+	}
+}

--- a/tests/phpunit/tests/model/test-model-subscription.php
+++ b/tests/phpunit/tests/model/test-model-subscription.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WP\Notifications\Test;
+
+use DateTime;
+use WP_UnitTestCase;
+use WP\Notifications\Model;
+
+class Test_Model_Subscription extends WP_UnitTestCase {
+
+	/**
+	 * Test message model.
+	 */
+	private ?Model\Subscription $model = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->model = new Model\Subscription(
+			'core/test',
+			1,
+			null,
+			new DateTime( '2023-12-31' )
+		);
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->model = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should be JSON serializable.
+	 */
+	public function test_json_serializable() {
+		$actual   = json_encode( $this->model, JSON_PRETTY_PRINT );
+		$expected = '{
+    "channel_name": "core\/test",
+    "created_at": null,
+    "snoozed_until": "2023-12-31T00:00:00+00:00",
+    "user_id": 1
+}';
+		$this->assertEquals( $actual, $expected );
+	}
+}

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -33,9 +33,14 @@ if ( ! defined( 'WP_FEATURE_NOTIFICATION_PLUGIN_DIR_URL' ) ) {
 
 // Require interface/class declarations..
 
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/helper/class-serde.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/interface-exception.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/class-runtime-exception.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/interface-status.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-channel.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-message.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-notification.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-subscription.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/image/interface-image.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/image/class-base-image.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/persistence/interface-notification-repository.php';


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add the initial models

- `Model\Channel`
- `Model\Message`
- `Model\Notification`
- `Model\Subscription`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

These are the base of models developed in #259. 

## Notes

All the properties are nullable, because I intend to support the `_fields` rest option, which means the models might not be initialized with all of their properties, just what the api has requested. I’ll build that in later, but currently the `jsonSerialize` function always returns all property’s of the model, I think this is fine for now. I will build out a validation system that will actually ensure the model properties are valid on insert and update.
