### PR TITLE
feature(mvp): Stage 3 - add initial factory classes

### DIFF
--- a/includes/factory/class-message.php
+++ b/includes/factory/class-message.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Notifications API:Messages factory class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Factory;
+
+use DateTime;
+use WP\Notifications\Framework;
+use WP\Notifications\Model;
+
+/**
+ * Class representing a messages factory.
+ *
+ * @implements Framework\Factory<Message>
+ */
+class Message extends Framework\Factory {
+
+	/**
+	 * Instantiates a Message object.
+	 *
+	 * @param array|string   $args    {
+	 *     Array or string of arguments for creating a message. Supported arguments
+	 *     are described below.
+	 *
+	 *     @type string    $message        Text content of the message.
+	 *     @type ?string   $accept_label   Optional label of the accept action.
+	 *     @type ?string   $accept_link    Optional url of the accept action.
+	 *     @type ?string   $accept_message Optional label of the accept action.
+	 *     @type ?string   $channel_title  Optional human-readable title of the channel
+	 *                                     the message was emitted from.
+	 *     @type ?DateTime $created_at     Optional datetime at which a message was created.
+	 *                                     Default `'null'`
+	 *     @type ?string   $dismiss_label  Optional label of the dismiss action.
+	 *     @type ?DateTime $expires_at     Optional datetime at which a message expires.
+	 *                                     Default `'null'`
+	 *     @type ?string   $icon           Optional icon of the message. Default `null`
+	 *     @type ?int      $id             Optional database ID of the message. Default `null`
+	 *     @type bool      $is_dismissible Optional boolean of whether the notice can
+	 *                                     be dismissed. Default `true`
+	 *     @type ?string   $severity       Optional severity of the message. Default `null`
+	 *     @type string    $title          Optional human-readable message label. Default `''`
+	 * }
+	 *
+	 * @return Model\Message|false A newly created instance of Message or false.
+	 */
+	public function make( $args ) {
+		$parsed = wp_parse_args( $args );
+
+		// Required properties
+
+		$message = $parsed['message'];
+
+		// Optional properties
+
+		$accept_label   = array_key_exists( 'accept_label', $parsed ) ? $parsed['accept_label'] : null;
+		$accept_link    = array_key_exists( 'accept_link', $parsed ) ? $parsed['accept_link'] : null;
+		$channel_title  = array_key_exists( 'channel_title', $parsed ) ? $parsed['channel_title'] : null;
+		$created_at     = array_key_exists( 'created_at', $parsed ) ? $parsed['created_at'] : null;
+		$dismiss_label  = array_key_exists( 'dismiss_label', $parsed ) ? $parsed['dismiss_label'] : null;
+		$expires_at     = array_key_exists( 'expires_at', $parsed ) ? $parsed['expires_at'] : null;
+		$icon           = array_key_exists( 'icon', $parsed ) ? $parsed['icon'] : null;
+		$id             = array_key_exists( 'id', $parsed ) ? $parsed['id'] : null;
+		$is_dismissible = array_key_exists( 'is_dismissible', $parsed ) ? $parsed['is_dismissible'] : true;
+		$severity       = array_key_exists( 'severity', $parsed ) ? $parsed['severity'] : null;
+		$title          = array_key_exists( 'title', $parsed ) ? $parsed['title'] : '';
+
+		return new Model\Message(
+			$message,
+			$accept_label,
+			$accept_link,
+			$channel_title,
+			$created_at,
+			$dismiss_label,
+			$expires_at,
+			$icon,
+			$id,
+			$is_dismissible,
+			$severity,
+			$title,
+		);
+	}
+}

--- a/includes/factory/class-message.php
+++ b/includes/factory/class-message.php
@@ -25,7 +25,7 @@ class Message extends Framework\Factory {
 	 *     Array or string of arguments for creating a message. Supported arguments
 	 *     are described below.
 	 *
-	 *     @type string    $message        Text content of the message.
+	 *     @type ?string   $message        Text content of the message.
 	 *     @type ?string   $accept_label   Optional label of the accept action.
 	 *     @type ?string   $accept_link    Optional url of the accept action.
 	 *     @type ?string   $accept_message Optional label of the accept action.
@@ -38,20 +38,20 @@ class Message extends Framework\Factory {
 	 *                                     Default `'null'`
 	 *     @type ?string   $icon           Optional icon of the message. Default `null`
 	 *     @type ?int      $id             Optional database ID of the message. Default `null`
-	 *     @type bool      $is_dismissible Optional boolean of whether the notice can
+	 *     @type ?bool     $is_dismissible Optional boolean of whether the notice can
 	 *                                     be dismissed. Default `true`
 	 *     @type ?string   $severity       Optional severity of the message. Default `null`
 	 *     @type string    $title          Optional human-readable message label. Default `''`
 	 * }
 	 *
-	 * @return Model\Message|false A newly created instance of Message or false.
+	 * @return Model\Message A newly created instance of Message or false.
 	 */
-	public function make( $args ) {
+	public function make( $args = array() ): Model\Message {
 		$parsed = wp_parse_args( $args );
 
 		// Required properties
 
-		$message = $parsed['message'];
+		$message = array_key_exists( 'message', $parsed ) ? $parsed['message'] : null;
 
 		// Optional properties
 

--- a/includes/factory/class-notification.php
+++ b/includes/factory/class-notification.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Notifications API:Notifications factory class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Factory;
+
+use DateTime;
+use WP\Notifications\Framework;
+use WP\Notifications\Helper;
+use WP\Notifications\Model;
+
+/**
+ * Class representing a notifications factory.
+ *
+ * @implements Framework\Factory<Notification>
+ */
+class Notification extends Framework\Factory {
+
+	/**
+	 * Instantiates a Notification object.
+
+	 * @param array|string $args     {
+	 *     Array or string of arguments for creating a notification. Supported arguments are described below.
+	 *
+	 *     @type string               $channel_name Channel name, including namespace,
+	 *                                              the notification was emitted from.
+	 *     @type int                  $message_id   ID of the message related to the
+	 *                                              notification.
+	 *     @type int                  $user_id      ID of the user the notification
+	 *                                              belongs to.
+	 *     @type ?string              $context      Optional display context of the
+	 *                                              notification. Default `'adminbar'`
+	 *     @type string|DateTime|null $created_at   Optional datetime at which the
+	 *                                              notification was created. Default `null`
+	 *     @type string|DateTime|null $dismissed_at Optional datetime  t which the
+	 *                                              notification was dismissed. Default `null`
+	 *     @type string|DateTime|null $displayed_at Optional datetime at which the
+	 *                                              notification was first displayed.
+	 *                                              Default `null`
+	 *     @type string|DateTime|null $expires_at   Optional datetime at which the
+	 *                                              notification expires. Default `null`
+	 * }
+	 * @param bool         $validate Optionally validate the arguments.
+	 *
+	 * @return Model\Notification|false A newly created instance of Channel or false.
+	 */
+	public function make( $args ) {
+		$parsed = wp_parse_args( $args );
+
+		// Required properties
+
+		$channel_name = $parsed['channel_name'];
+		$message_id   = $parsed['message_id'];
+		$user_id      = $parsed['user_id'];
+
+		// Optional properties
+
+		$context      = array_key_exists( 'context', $parsed ) ? $parsed['context'] : 'adminbar';
+		$created_at   = array_key_exists( 'created_at', $parsed ) ? $parsed['created_at'] : null;
+		$dismissed_at = array_key_exists( 'dismissed_at', $parsed ) ? $parsed['dismissed_at'] : null;
+		$displayed_at = array_key_exists( 'displayed_at', $parsed ) ? $parsed['displayed_at'] : null;
+		$expires_at   = array_key_exists( 'expires_at', $parsed ) ? $parsed['expires_at'] : null;
+
+		// Deserialize MySQL datetime strings.
+
+		$created_at   = Helper\Serde::maybe_deserialize_mysql_date( $created_at );
+		$dismissed_at = Helper\Serde::maybe_deserialize_mysql_date( $dismissed_at );
+		$displayed_at = Helper\Serde::maybe_deserialize_mysql_date( $displayed_at );
+		$expires_at   = Helper\Serde::maybe_deserialize_mysql_date( $expires_at );
+
+		$notification = new Model\Notification(
+			$channel_name,
+			$message_id,
+			$user_id,
+			$context,
+			$created_at,
+			$dismissed_at,
+			$displayed_at,
+			$expires_at
+		);
+
+		return $notification;
+	}
+}

--- a/includes/factory/class-notification.php
+++ b/includes/factory/class-notification.php
@@ -25,11 +25,11 @@ class Notification extends Framework\Factory {
 	 * @param array|string $args     {
 	 *     Array or string of arguments for creating a notification. Supported arguments are described below.
 	 *
-	 *     @type string               $channel_name Channel name, including namespace,
+	 *     @type ?string              $channel_name Channel name, including namespace,
 	 *                                              the notification was emitted from.
-	 *     @type int                  $message_id   ID of the message related to the
+	 *     @type ?int                 $message_id   ID of the message related to the
 	 *                                              notification.
-	 *     @type int                  $user_id      ID of the user the notification
+	 *     @type ?int                 $user_id      ID of the user the notification
 	 *                                              belongs to.
 	 *     @type ?string              $context      Optional display context of the
 	 *                                              notification. Default `'adminbar'`
@@ -43,18 +43,17 @@ class Notification extends Framework\Factory {
 	 *     @type string|DateTime|null $expires_at   Optional datetime at which the
 	 *                                              notification expires. Default `null`
 	 * }
-	 * @param bool         $validate Optionally validate the arguments.
 	 *
-	 * @return Model\Notification|false A newly created instance of Channel or false.
+	 * @return Model\Notification A newly created instance of Channel or false.
 	 */
-	public function make( $args ) {
+	public function make( $args = array() ): Model\Notification {
 		$parsed = wp_parse_args( $args );
 
 		// Required properties
 
-		$channel_name = $parsed['channel_name'];
-		$message_id   = $parsed['message_id'];
-		$user_id      = $parsed['user_id'];
+		$channel_name = array_key_exists( 'channel_name', $parsed ) ? $parsed['channel_name'] : null;
+		$message_id   = array_key_exists( 'message_id', $parsed ) ? $parsed['message_id'] : null;
+		$user_id      = array_key_exists( 'user_id', $parsed ) ? $parsed['user_id'] : null;
 
 		// Optional properties
 
@@ -71,7 +70,7 @@ class Notification extends Framework\Factory {
 		$displayed_at = Helper\Serde::maybe_deserialize_mysql_date( $displayed_at );
 		$expires_at   = Helper\Serde::maybe_deserialize_mysql_date( $expires_at );
 
-		$notification = new Model\Notification(
+		return new Model\Notification(
 			$channel_name,
 			$message_id,
 			$user_id,
@@ -81,7 +80,5 @@ class Notification extends Framework\Factory {
 			$displayed_at,
 			$expires_at
 		);
-
-		return $notification;
 	}
 }

--- a/includes/factory/class-subscription.php
+++ b/includes/factory/class-subscription.php
@@ -26,9 +26,9 @@ class Subscription extends Framework\Factory {
 	 *     Array or string of arguments for creating a subscription. Supported
 	 *     arguments are described below.
 	 *
-	 *     @type string               $channel_name  Namespaced channel name of the
+	 *     @type ?string              $channel_name  Namespaced channel name of the
 	 *                                               subscription.
-	 *     @type int                  $user_id       ID of the user the subscription
+	 *     @type ?int                 $user_id       ID of the user the subscription
 	 *                                               belongs to.
 	 *     @type string|DateTime|null $created_at    Optional datetime at which the
 	 *                                               subscription was created.
@@ -36,15 +36,15 @@ class Subscription extends Framework\Factory {
 	 *                                               of the subscription.
 	 * }
 	 *
-	 * @return Model\Subscription|false A newly created instance of Subscription or false.
+	 * @return Model\Subscription A newly created instance of Subscription or false.
 	 */
-	public function make( $args ) {
+	public function make( $args = array() ): Model\Subscription {
 		$parsed = wp_parse_args( $args );
 
 		// Required properties
 
-		$channel_name = $parsed['channel_name'];
-		$user_id      = $parsed['user_id'];
+		$channel_name = array_key_exists( 'channel_name', $parsed ) ? $parsed['channel_name'] : null;
+		$user_id      = array_key_exists( 'user_id', $parsed ) ? $parsed['user_id'] : null;
 
 		// Optional properties
 
@@ -56,13 +56,11 @@ class Subscription extends Framework\Factory {
 		$created_at    = Helper\Serde::maybe_deserialize_mysql_date( $created_at );
 		$snoozed_until = Helper\Serde::maybe_deserialize_mysql_date( $snoozed_until );
 
-		$subscription = new Model\Subscription(
+		return new Model\Subscription(
 			$channel_name,
 			$user_id,
 			$created_at,
 			$snoozed_until,
 		);
-
-		return $subscription;
 	}
 }

--- a/includes/factory/class-subscription.php
+++ b/includes/factory/class-subscription.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Notifications API:Subscriptions factory class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Factory;
+
+use DateTime;
+use WP\Notifications\Framework;
+use WP\Notifications\Helper;
+use WP\Notifications\Model;
+
+/**
+ * Class representing a subscriptions factory
+ *
+ * @implements Framework\Factory<Subscription>.
+ */
+class Subscription extends Framework\Factory {
+
+	/**
+	 * Instantiates a Subscription object.
+	 *
+	 * @param array|string $args     {
+	 *     Array or string of arguments for creating a subscription. Supported
+	 *     arguments are described below.
+	 *
+	 *     @type string               $channel_name  Namespaced channel name of the
+	 *                                               subscription.
+	 *     @type int                  $user_id       ID of the user the subscription
+	 *                                               belongs to.
+	 *     @type string|DateTime|null $created_at    Optional datetime at which the
+	 *                                               subscription was created.
+	 *     @type string|DateTime|null $snoozed_until Optional snoozed until datetime
+	 *                                               of the subscription.
+	 * }
+	 *
+	 * @return Model\Subscription|false A newly created instance of Subscription or false.
+	 */
+	public function make( $args ) {
+		$parsed = wp_parse_args( $args );
+
+		// Required properties
+
+		$channel_name = $parsed['channel_name'];
+		$user_id      = $parsed['user_id'];
+
+		// Optional properties
+
+		$created_at    = array_key_exists( 'created_at', $parsed ) ? $parsed['created_at'] : null;
+		$snoozed_until = array_key_exists( 'snoozed_until', $parsed ) ? $parsed['snoozed_until'] : null;
+
+		// Deserialize MySQL datetime strings.
+
+		$created_at    = Helper\Serde::maybe_deserialize_mysql_date( $created_at );
+		$snoozed_until = Helper\Serde::maybe_deserialize_mysql_date( $snoozed_until );
+
+		$subscription = new Model\Subscription(
+			$channel_name,
+			$user_id,
+			$created_at,
+			$snoozed_until,
+		);
+
+		return $subscription;
+	}
+}

--- a/includes/framework/class-factory.php
+++ b/includes/framework/class-factory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Notifications API:Factory abstract class
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\Framework;
+
+/**
+ * Abstract class representing a factory.
+ *
+ * @template Model
+ */
+abstract class Factory {
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @var ?Model
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Instantiates a model object.
+
+	 * @param array|string $args Array or string of arguments for creating a model.
+
+	 *
+	 * @return Model|false A newly created instance of model or false.
+	 */
+	abstract public function make( $args );
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @return Model The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+}

--- a/includes/framework/class-factory.php
+++ b/includes/framework/class-factory.php
@@ -17,15 +17,14 @@ abstract class Factory {
 	/**
 	 * Container for the main instance of the class.
 	 *
-	 * @var ?Model
+	 * @property ?Model
 	 */
 	protected static $instance = null;
 
 	/**
 	 * Instantiates a model object.
-
+	 *
 	 * @param array|string $args Array or string of arguments for creating a model.
-
 	 *
 	 * @return Model|false A newly created instance of model or false.
 	 */
@@ -40,7 +39,7 @@ abstract class Factory {
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
-			self::$instance = new self();
+			self::$instance = new static();
 		}
 
 		return self::$instance;

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -38,4 +38,4 @@ require $tests_dir . '/includes/bootstrap.php';
 
 remove_filter( 'wp_die_handler', 'handle_wp_setup_failure' );
 
-require dirname( __FILE__ ) . '/class-test-case.php';
+require dirname( __FILE__ ) . '/class-testcase.php';

--- a/tests/phpunit/includes/class-test-case.php
+++ b/tests/phpunit/includes/class-test-case.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace WP\Notifications\Tests;
-
-class TestCase extends \PHPUnit\Framework\TestCase {
-
-}

--- a/tests/phpunit/includes/class-testcase.php
+++ b/tests/phpunit/includes/class-testcase.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace WP\Notifications\Tests;
+
+use PHPUnit_Adapter_TestCase;
+
+class TestCase extends PHPUnit_Adapter_TestCase {
+
+}

--- a/tests/phpunit/tests/factory/test-factory-message.php
+++ b/tests/phpunit/tests/factory/test-factory-message.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WP\Notifications\Tests;
+
+use WP\Notifications\Factory;
+
+class Test_Factory_Message extends TestCase {
+
+	/**
+	 * Test message factory.
+	 */
+	protected ?Factory\Message $factory = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->factory = new Factory\Message();
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->factory = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should create an instance of the message model class.
+	 */
+	public function test_makes_message_instance() {
+		$actual = $this->factory->make();
+		$this->assertInstanceOf( '\WP\Notifications\Model\Message', $actual );
+	}
+}

--- a/tests/phpunit/tests/factory/test-factory-notification.php
+++ b/tests/phpunit/tests/factory/test-factory-notification.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WP\Notifications\Tests;
+
+use WP\Notifications\Factory;
+
+class Test_Factory_Notification extends TestCase {
+
+	/**
+	 * Test notification factory.
+	 */
+	protected ?Factory\Notification $factory = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->factory = new Factory\Notification();
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->factory = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should create an instance of the notification model class.
+	 */
+	public function test_makes_notification_instance() {
+		$actual = $this->factory->make();
+		$this->assertInstanceOf( '\WP\Notifications\Model\Notification', $actual );
+	}
+}

--- a/tests/phpunit/tests/factory/test-factory-subscription.php
+++ b/tests/phpunit/tests/factory/test-factory-subscription.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WP\Notifications\Tests;
+
+use WP\Notifications\Factory;
+
+class Test_Factory_Subscription extends TestCase {
+
+	/**
+	 * Test subscription factory.
+	 */
+	protected ?Factory\Subscription $factory = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->factory = new Factory\Subscription();
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->factory = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should create an instance of the subscription model class.
+	 */
+	public function test_makes_subscription_instance() {
+		$actual = $this->factory->make();
+		$this->assertInstanceOf( '\WP\Notifications\Model\Subscription', $actual );
+	}
+}

--- a/tests/phpunit/tests/model/test-model-channel.php
+++ b/tests/phpunit/tests/model/test-model-channel.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace WP\Notifications\Test;
+namespace WP\Notifications\Tests;
 
-use WP_UnitTestCase;
 use WP\Notifications\Model;
 
-class Test_Model_Channel extends WP_UnitTestCase {
+class Test_Model_Channel extends TestCase {
 
 	/**
 	 * Test channel model.

--- a/tests/phpunit/tests/model/test-model-message.php
+++ b/tests/phpunit/tests/model/test-model-message.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace WP\Notifications\Test;
+namespace WP\Notifications\Tests;
 
-use WP_UnitTestCase;
 use WP\Notifications\Model;
 
-class Test_Model_Message extends WP_UnitTestCase {
+class Test_Model_Message extends TestCase {
 
 	/**
 	 * Test message model.

--- a/tests/phpunit/tests/model/test-model-notification.php
+++ b/tests/phpunit/tests/model/test-model-notification.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace WP\Notifications\Test;
+namespace WP\Notifications\Tests;
 
 use DateTime;
-use WP_UnitTestCase;
 use WP\Notifications\Model;
 
-class Test_Model_Notification extends WP_UnitTestCase {
+class Test_Model_Notification extends TestCase {
 
 	/**
 	 * Test message model.

--- a/tests/phpunit/tests/model/test-model-subscription.php
+++ b/tests/phpunit/tests/model/test-model-subscription.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace WP\Notifications\Test;
+namespace WP\Notifications\Tests;
 
 use DateTime;
-use WP_UnitTestCase;
 use WP\Notifications\Model;
 
-class Test_Model_Subscription extends WP_UnitTestCase {
+class Test_Model_Subscription extends TestCase {
 
 	/**
 	 * Test message model.

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -33,6 +33,7 @@ if ( ! defined( 'WP_FEATURE_NOTIFICATION_PLUGIN_DIR_URL' ) ) {
 
 // Require interface/class declarations..
 
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/framework/class-factory.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/helper/class-serde.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/interface-exception.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/exceptions/class-runtime-exception.php';
@@ -41,6 +42,9 @@ require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-channel
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-message.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-notification.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-subscription.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/factory/class-message.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/factory/class-notification.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/factory/class-subscription.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-channel-registry.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/channels.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/image/interface-image.php';


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add the initial factory classes.

- `Factory\Message`
- `Factory\Notification`
- `Factory\Subscription`
- `Framework\Factory`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Builds on the models of #289. Abstracts the creation of model objects using an array argument through the factory.

~Blocked until #289 is merged.~

**Additionally**

- Modified the base `TestCase` to be based on `PHPUnit_Adapter_TestCase`.