### PR TITLE
feature(mvp): Stage 3 - add channel registry

### DIFF
--- a/includes/channels.php
+++ b/includes/channels.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Notifications API:channels Functions for registering channels.
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+use WP\Notification\Model;
+
+/**
+ * Register a notification channel.
+ *
+ * @param string|Model\Channel $name  Channel name including namespace, or
+ *                                    alternatively a complete Channel instance.
+ *                                    Incase a Channel is provided, the $args
+ *                                    parameter will be ignored.
+ * @param array                $args  Optional. Array of channel arguments. Accepts
+ *                                    any public property of `Channel`. See
+ *                                    Channel::__construct() for information on
+ *                                    accepted arguments. Default empty array.
+ * @return Model\Channel|false The registered channel on success, or false on failure.
+ */
+function register_channel( $name, $args = array() ) {
+	return Channel_Registry::get_instance()->register( $name, $args );
+}
+
+/**
+ * Unregister a channel.
+ *
+ * @param string|Model\Channel $name Channel name including namespace, or
+ *                                   alternatively a complete Channel instance.
+ * @return Model\Channel|false The unregistered channel on success, or false on failure.
+ */
+function unregister_channel( $name ) {
+	return Channel_Registry::get_instance()->unregister( $name );
+}
+
+// Register core notification channels.
+
+add_action(
+	'init',
+	function () {
+		register_channel(
+			'core/updates',
+			array(
+				'title'       => __( 'WordPress Updates', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'WordPress core update events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/plugin-install',
+			array(
+				'title'       => __( 'Plugin Install', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Plugin install events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/plugin-uninstall',
+			array(
+				'title'       => __( 'Plugin Uninstall', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Plugin uninstall events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/plugin-activate',
+			array(
+				'title'       => __( 'Plugin Activate', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Plugin activation events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/plugin-deactivate',
+			array(
+				'title'       => __( 'Plugin Deactivate', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Plugin deactivation events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/plugin-updates',
+			array(
+				'title'       => __( 'Plugin Update', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Plugin update events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/post-new',
+			array(
+				'title'       => __( 'New Post', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Post creation events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/post-edit',
+			array(
+				'title'       => __( 'Edit Post', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Post edit events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/post-delete',
+			array(
+				'title'       => __( 'Delete Post', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Post delete events.', 'wp-feature-notifications' ),
+			)
+		);
+
+		register_channel(
+			'core/comment-new',
+			array(
+				'title'       => __( 'New Comment', 'wp-feature-notifications' ),
+				'icon'        => 'wordpress',
+				'description' => __( 'Comment creation events.', 'wp-feature-notifications' ),
+			)
+		);
+	}
+);

--- a/includes/class-channel-registry.php
+++ b/includes/class-channel-registry.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Notifications API:Channel_Registry class
+ *
+ * Heavy inspired by the `WP_Block_Type_Registry`.
+ *
+ * The registered channels are stored in code, not in the database. If the data were
+ * stored in the database it would require a lookup to ensure the registered channel
+ * matched it's value in the database based. Since the channels can be registered by
+ * plugins, which maybe be uninstalled, the notification system cannot rely on the
+ * presence of the `Channel` instance after an initial render of a notification
+ * message. The namespaced channel name is the key used to look up a user's
+ * subscription to a channel.
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications;
+
+use WP\Notifications\Model;
+
+/**
+ * Class used for interacting with channels.
+ */
+final class Channel_Registry {
+
+	/**
+	 * Registered channels, as `$name => $instance` pairs.
+	 *
+	 * @var Model\Channel[]
+	 */
+	private $registered_channels = array();
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @var Channel_Registry|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Registers a channel.
+	 *
+	 * @see \WP\Notifications\Model\Channel::__construct()
+	 *
+	 * @param string|Model\Channel $name Channel name including namespace, or
+	 *                                   alternatively a complete Channel instance.
+	 *                                   In case a Channel is provided, the $args
+	 *                                   parameter will be ignored.
+	 * @param array|string         $args {
+	 *     Array or string of arguments for registering a channel. Supported arguments
+	 *     are described below.
+	 *
+	 *     @type string      $title       Human-readable label of the channel.
+	 *     @type string|null $context     Optional display context of the channel
+	 *     @type string|null $description Optional detailed description of the channel.
+	 *     @type string|null $icon        Optional icon of the channel.
+	 * }
+	 * @return Model\Channel|false The registered channel on success, or false on failure.
+	 */
+	public function register( $name, $args = array() ) {
+		$channel = null;
+
+		if ( $name instanceof Model\Channel ) {
+			$channel = $name;
+			$name    = $channel->get_name();
+		}
+
+		if ( ! is_string( $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Channel names must be strings.' ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		if ( preg_match( '/[A-Z]+/', $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Channel names must not contain uppercase characters.' ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		$name_matcher = '/^[a-z0-9-]+\/[a-z0-9-]+$/';
+		if ( ! preg_match( $name_matcher, $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Channel names must contain a namespace prefix. Example: my-plugin/my-channel' ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		if ( $this->is_registered( $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Channel name. */
+				sprintf( __( 'Channel "%s" is already registered.' ), $name ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		if ( ! $channel ) {
+			$parsed = wp_parse_args( $args );
+
+			$title       = $parsed['title'];
+			$context     = array_key_exists( 'context', $parsed ) ? $parsed['context'] : null;
+			$description = array_key_exists( 'description', $parsed ) ? $parsed['description'] : null;
+			$icon        = array_key_exists( 'icon', $parsed ) ? $parsed['icon'] : null;
+
+			$channel = new Model\Channel( $name, $title, $context, $description, $icon );
+		}
+
+		$this->registered_channels[ $channel->get_name() ] = $channel;
+
+		return $channel;
+	}
+
+	/**
+	 * Unregister a channel.
+	 *
+	 * @param string|Model/Channel $name Channel type name including namespace, or
+	 *                                   alternatively a complete Channel instance.
+	 * @return Model/Channel|false The unregistered channel on success, or false on failure.
+	 */
+	public function unregister( $name ) {
+		if ( $name instanceof Channel ) {
+			$name = $name->get_name();
+		}
+
+		if ( ! $this->is_registered( $name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Channel name. */
+				sprintf( __( 'Channel "%s" is not registered.' ), $name ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		$unregistered_channel = $this->registered_channels[ $name ];
+		unset( $this->registered_channels[ $name ] );
+
+		return $unregistered_channel;
+	}
+
+	/**
+	 * Retrieves a registered channel.
+	 *
+	 * @param string $name Channel name including namespace.
+	 *
+	 * @return Model\Channel|null The registered channel, or null if it is not registered.
+	 */
+	public function get_registered( $name ) {
+		if ( ! $this->is_registered( $name ) ) {
+			return null;
+		}
+
+		return $this->registered_channels[ $name ];
+	}
+
+	/**
+	 * Retrieves all registered channels.
+	 *
+	 * @return Model\Channel[] Associative array of `$channel_name => $channel` pairs.
+	 */
+	public function get_all_registered() {
+		return $this->registered_channels;
+	}
+
+	/**
+	 * Checks if a channel is registered.
+	 *
+	 * @param string $name Chanel name including namespace.
+	 *
+	 * @return bool True if the channel is registered, false otherwise.
+	 */
+	public function is_registered( $name ) {
+		return isset( $this->registered_channels[ $name ] );
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @return Channel_Registry The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+}

--- a/includes/class-channel-registry.php
+++ b/includes/class-channel-registry.php
@@ -123,12 +123,12 @@ final class Channel_Registry {
 	/**
 	 * Unregister a channel.
 	 *
-	 * @param string|Model/Channel $name Channel type name including namespace, or
+	 * @param string|Model\Channel $name Channel type name including namespace, or
 	 *                                   alternatively a complete Channel instance.
-	 * @return Model/Channel|false The unregistered channel on success, or false on failure.
+	 * @return Model\Channel|false The unregistered channel on success, or false on failure.
 	 */
 	public function unregister( $name ) {
-		if ( $name instanceof Channel ) {
+		if ( $name instanceof Model\Channel ) {
 			$name = $name->get_name();
 		}
 

--- a/tests/phpunit/tests/test-channel-registry.php
+++ b/tests/phpunit/tests/test-channel-registry.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace WP\Notifications\Test;
+
+use WP_UnitTestCase;
+use WP\Notifications;
+use WP\Notifications\Model;
+
+class Test_Channel_Registry extends WP_UnitTestCase {
+	/**
+	 * Fake channel registry.
+	 *
+	 * @var Channel_Registry
+	 */
+	private $registry = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->registry = new Notifications\Channel_Registry();
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$this->registry = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should reject channel without a namespace.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	 */
+	public function test_invalid_names_without_namespace() {
+		$result = $this->registry->register( 'test', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should reject channels with invalid characters.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	 */
+	public function test_invalid_characters() {
+		$result = $this->registry->register( 'test/_doing_it_wrong', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should reject channels with uppercase characters.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	 */
+	public function test_uppercase_characters() {
+		$result = $this->registry->register( 'Core/Test', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should accept valid channel names
+	 */
+	public function test_register_channel() {
+		$name     = 'core/test';
+		$settings = array(
+			'title' => 'Test Channel',
+		);
+
+		$channel = $this->registry->register( $name, $settings );
+		$this->assertSame( $name, $channel->get_name() );
+		$this->assertSame( $settings['title'], $channel->get_title() );
+		$this->assertSame( $channel, $this->registry->get_registered( $name ) );
+	}
+
+	/**
+	 * Should fail to re-register the same channel.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::register
+	 */
+	public function test_register_channel_twice() {
+		$name     = 'core/test';
+		$settings = array(
+			'title' => 'Test Channel',
+		);
+
+		$result = $this->registry->register( $name, $settings );
+		$this->assertNotFalse( $result );
+		$result = $this->registry->register( $name, $settings );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should accept a Channel instance.
+	 */
+	public function test_register_channel_instance() {
+		$channel = new Model\Channel( 'core/test', 'Test Channel' );
+
+		$result = $this->registry->register( $channel );
+		$this->assertSame( $channel, $result );
+	}
+
+	/**
+	 * Unregistering should fail if a channel is not registered.
+	 *
+	 * @expectedIncorrectUsage WP\Notifications\Channel_Registry::unregister
+	 */
+	public function test_unregister_not_registered_channel() {
+		$result = $this->registry->unregister( 'core/unregistered' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should unregister existing channels.
+	 */
+	public function test_unregister_channel() {
+		$name     = 'core/test';
+		$settings = array(
+			'title' => 'Test Channel',
+		);
+
+		$this->registry->register( $name, $settings );
+		$channel = $this->registry->unregister( $name );
+		$this->assertSame( $name, $channel->get_name() );
+		$this->assertSame( $settings['title'], $channel->get_title() );
+		$this->assertFalse( $this->registry->is_registered( $name ) );
+	}
+
+	/**
+	 * Should return all registered channels.
+	 */
+	public function test_get_all_registered() {
+		$names    = array( 'core/updates', 'core/post-edit', 'core/post-delete' );
+		$settings = array(
+			'title' => 'random',
+		);
+
+		foreach ( $names as $name ) {
+			$this->registry->register( $name, $settings );
+		}
+
+		$registered = $this->registry->get_all_registered();
+		$this->assertSameSets( $names, array_keys( $registered ) );
+	}
+}

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -41,6 +41,8 @@ require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-channel
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-message.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-notification.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/model/class-subscription.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-channel-registry.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/channels.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/image/interface-image.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/image/class-base-image.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/persistence/interface-notification-repository.php';


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add functions and a registry for managing channels.

- `Channel_Registry` class
- `register_channel` function
- `unregister_channel` function

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

The `Channel` objects will be held entirely in code. The registry is highly influenced by the `WP_Block_Type_Registry`.