### PR TITLE
Style: custom props names prefix replaced with "--wp-notifications-*"

### DIFF
--- a/src/styles/components/bullet.scss
+++ b/src/styles/components/bullet.scss
@@ -19,11 +19,11 @@ $bullet-width: 6px;
 		left: #{ (-36px - $bullet-width) * 0.5 }; // 9 - left padding - border /2  + bullet/2
 
 		border-radius: 50%;
-		background: var(--wp-notify--color--link);
+		background: var(--wp-notifications--color--link);
 	}
 }
 
 #wpadminbar .wp-notifications.new > :first-child::before {
-	top: calc(var(--wp-notify--hub-image-size) * 0.5 + var(--wp-notify--hub-spacing-top));
+	top: calc(var(--wp-notifications--hub-image-size) * 0.5 + var(--wp-notifications--hub-spacing-top));
 	left: 2px;
 }

--- a/src/styles/components/notification.scss
+++ b/src/styles/components/notification.scss
@@ -2,18 +2,18 @@
  * General notifications style
  */
 .wp-notification {
-	background: var(--wp-notify--color--background);
-	color: var(--wp-notify--color--primary);
+	background: var(--wp-notifications--color--background);
+	color: var(--wp-notifications--color--primary);
 	overflow: hidden;
 	max-height: 600px;
 
 	&-action {
 		text-decoration-line: underline;
-		color: var(--wp-notify--color--link);
+		color: var(--wp-notifications--color--link);
 	}
 
 	&-meta {
-		color: var(--wp-notify--color--secondary);
+		color: var(--wp-notifications--color--secondary);
 	}
 
 	// TODO exit animation

--- a/src/styles/dashboard/notice.scss
+++ b/src/styles/dashboard/notice.scss
@@ -8,9 +8,9 @@
 	}
 
 	.wp-notification {
-		--wp-notify--hub-spacing-top: clamp(1em, 3vh, 2em);
-		--wp-notify--hub-element-bottom: clamp(1em, 3vh, 2em);
-		--wp-notify--hub-spacing-gap: clamp(2em, 3vh, 3em);
+		--wp-notifications--hub-spacing-top: clamp(1em, 3vh, 2em);
+		--wp-notifications--hub-element-bottom: clamp(1em, 3vh, 2em);
+		--wp-notifications--hub-spacing-gap: clamp(2em, 3vh, 3em);
 
 		width: 100%;
 		box-sizing: border-box;
@@ -23,14 +23,14 @@
 
 		justify-content: space-between;
 
-		padding: var(--wp-notify--hub-spacing-top) 20px var(--wp-notify--hub-spacing-gap) 36px;
-		margin: 10px 0 var(--wp-notify--hub-element-bottom);
+		padding: var(--wp-notifications--hub-spacing-top) 20px var(--wp-notifications--hub-spacing-gap) 36px;
+		margin: 10px 0 var(--wp-notifications--hub-element-bottom);
 		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 
 		// the notification left border
 		border-left-width: 4px;
 		border-left-style: solid;
-		border-color: var(--wp-notify--color--primary);
+		border-color: var(--wp-notifications--color--primary);
 
 		@media #{$breakpoint} {
 			grid-template-columns: auto;
@@ -60,7 +60,7 @@
 
 		// join subsequent notifications
 		+ .wp-notification {
-			margin-top: calc(var(--wp-notify--hub-element-bottom) * -1);
+			margin-top: calc(var(--wp-notifications--hub-element-bottom) * -1);
 			border-top: none;
 		}
 

--- a/src/styles/hub/elements.scss
+++ b/src/styles/hub/elements.scss
@@ -26,7 +26,7 @@
 		top: 0;
 		background: $color-white;
 		box-shadow: 0 0 0 1px $color-white;
-		padding: 0 var(--wp-notify--hub-spacing-horizontal) 10px;
+		padding: 0 var(--wp-notifications--hub-spacing-horizontal) 10px;
 
 		.wp-notifications-action.mark-as-read {
 
@@ -53,7 +53,7 @@
 		&::before {
 			content: "";
 			display: block;
-			box-shadow: 0 1rem 24px 2px var(--wp-notify--color--primary);
+			box-shadow: 0 1rem 24px 2px var(--wp-notifications--color--primary);
 			width: 80%;
 			margin: auto 10%;
 			position: absolute;
@@ -70,21 +70,21 @@
 			height: 56px;
 			width: 100%;
 			text-align: center;
-			background: var(--wp-notify--color--background);
-			padding: 15px var(--wp-notify--hub-spacing-horizontal);
+			background: var(--wp-notifications--color--background);
+			padding: 15px var(--wp-notifications--hub-spacing-horizontal);
 			border-top: 1px solid $color-black-400;
 
 			svg {
-				fill: var(--wp-notify--color--link);
+				fill: var(--wp-notifications--color--link);
 				vertical-align: middle;
 			}
 
 			&:hover,
 			&:focus {
-				color: var(--wp-notify--color--link-active);
+				color: var(--wp-notifications--color--link-active);
 
 				svg {
-					fill: var(--wp-notify--color--link-active);
+					fill: var(--wp-notifications--color--link-active);
 				}
 			}
 

--- a/src/styles/hub/layout.scss
+++ b/src/styles/hub/layout.scss
@@ -10,8 +10,8 @@
 	flex-direction: column;
 	height: 100%;
 	padding: 30px 0 0;
-	background: var(--wp-notify--color--background);
-	box-shadow: 0 0 24px -16px var(--wp-notify--color--primary);
+	background: var(--wp-notifications--color--background);
+	box-shadow: 0 0 24px -16px var(--wp-notifications--color--primary);
 	box-sizing: border-box;
 	overflow: hidden;
 
@@ -46,7 +46,7 @@
 				border: 6px solid transparent;
 				background-clip: padding-box;
 				-webkit-border-radius: 18px;
-				background-color: var(--wp-notify--color--scrollbar);
+				background-color: var(--wp-notifications--color--scrollbar);
 			}
 		}
 	}

--- a/src/styles/hub/notice.scss
+++ b/src/styles/hub/notice.scss
@@ -5,17 +5,17 @@
 
 	.wp-notification {
 		max-width: 100%;
-		margin-left: var(--wp-notify--hub-spacing-gap);
-		margin-right: var(--wp-notify--hub-spacing-gap);
+		margin-left: var(--wp-notifications--hub-spacing-gap);
+		margin-right: var(--wp-notifications--hub-spacing-gap);
 		user-select: none;
 		-webkit-user-drag: none;
 
-		padding: var(--wp-notify--hub-spacing-top) var(--wp-notify--hub-spacing-horizontal) var(--wp-notify--hub-spacing-gap);
+		padding: var(--wp-notifications--hub-spacing-top) var(--wp-notifications--hub-spacing-horizontal) var(--wp-notifications--hub-spacing-gap);
 
 		gap: 12px;
 		display: grid;
 		grid-template-rows: auto;
-		grid-template-columns: var(--wp-notify--hub-image-size) auto;
+		grid-template-columns: var(--wp-notifications--hub-image-size) auto;
 		grid-auto-flow: row;
 
 		// shows the selected item using the webkit default styling
@@ -49,9 +49,9 @@
 		}
 
 		&-image {
-			min-width: var(--wp-notify--hub-image-size);
-			width: var(--wp-notify--hub-image-size);
-			height: var(--wp-notify--hub-image-size);
+			min-width: var(--wp-notifications--hub-image-size);
+			width: var(--wp-notifications--hub-image-size);
+			height: var(--wp-notifications--hub-image-size);
 			position: relative;
 			grid-row: 1;
 
@@ -95,10 +95,10 @@
 	* Notice Severity
 	*/
 	$alertSeverity: (
-		"alert": var(--wp-notify--color--error),
-		"warning": var(--wp-notify--color--warning),
-		"success": var(--wp-notify--color--success),
-		"info": var(--wp-notify--color--info)
+		"alert": var(--wp-notifications--color--error),
+		"warning": var(--wp-notifications--color--warning),
+		"success": var(--wp-notifications--color--success),
+		"info": var(--wp-notifications--color--info)
 	);
 
 	@each $key, $value in $alertSeverity {

--- a/src/styles/vars.scss
+++ b/src/styles/vars.scss
@@ -20,28 +20,28 @@ $color-black: #000;        // Black
 
 // https://make.wordpress.org/design/handbook/design-guide/foundations/colors/
 :root {
-	--wp-notify--color--primary: #{$color-black-700};
-	--wp-notify--color--secondary: #{$color-black-500};
-	--wp-notify--color--background: #{$color-white};
+	--wp-notifications--color--primary: #{$color-black-700};
+	--wp-notifications--color--secondary: #{$color-black-500};
+	--wp-notifications--color--background: #{$color-white};
 
-	--wp-notify--color--scrollbar: #{$color-black-300};
-	--wp-notify--color--link: #{$color-blue};
-	--wp-notify--color--link-active: #{$color-blue-light};
-	--wp-notify--color--error: #{$color-red};
-	--wp-notify--color--info: #{$color-blue};
-	--wp-notify--color--warning: #{$color-yellow};
-	--wp-notify--color--success: #{$color-green};
+	--wp-notifications--color--scrollbar: #{$color-black-300};
+	--wp-notifications--color--link: #{$color-blue};
+	--wp-notifications--color--link-active: #{$color-blue-light};
+	--wp-notifications--color--error: #{$color-red};
+	--wp-notifications--color--info: #{$color-blue};
+	--wp-notifications--color--warning: #{$color-yellow};
+	--wp-notifications--color--success: #{$color-green};
 
 	// WP Notification Feature hub (admin top bar)
-	--wp-notify--hub-width: 320px;
+	--wp-notifications--hub-width: 320px;
 
 	@media #{$breakpoint} {
-		--wp-notify--hub-width: 100%;
+		--wp-notifications--hub-width: 100%;
 	}
-	--wp-notify--hub-image-size: 32px;
+	--wp-notifications--hub-image-size: 32px;
 
-	--wp-notify--hub-spacing-top: 15px;
-	--wp-notify--hub-spacing-bottom: 17px;
-	--wp-notify--hub-spacing-horizontal: 16px;
-	--wp-notify--hub-spacing-gap: 8px;
+	--wp-notifications--hub-spacing-top: 15px;
+	--wp-notifications--hub-spacing-bottom: 17px;
+	--wp-notifications--hub-spacing-horizontal: 16px;
+	--wp-notifications--hub-spacing-gap: 8px;
 }


### PR DESCRIPTION
## What?
Fixes the naming convention for css custom props

## How?
Replaces all the occurrences of "--wp-notify-*" with "--wp-notifications-*" in custom props names

relative to #197
