### PR TITLE
replace with same editorconfig as used in gutenberg

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,13 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
-indent_size = tab
-tab_width = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{gradle,java,kt}]
+indent_style = space
+
+[packages/react-native-*/**.xml]
+indent_style = space


### PR DESCRIPTION
## What?
I realised that the editorconfig was changed but that configuration always gave me troubles with js/webstorm, and may lead to a worse development experience

## Why?
`tab_width = 4` is forcing the ide to use this setting whereas if you do not set anything, you have the option of using your preference from the ide.
Fixes `Yaml` files that should not use tabs

## How?
Copy and pasted the gutenberg config file that is working fine https://github.com/WordPress/gutenberg/blob/trunk/.editorconfig
