### PR TITLE
feature(mvp): add initial channel and subscription rest controllers

### DIFF
--- a/includes/restapi/class-channel-controller.php
+++ b/includes/restapi/class-channel-controller.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Notifications API:Channel_Controller.
+ *
+ * @package wordpress/wp-feature-notifications
+ */
+
+namespace WP\Notifications\REST;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WP\Notifications;
+use WP\Notifications\Channel_Registry;
+
+/**
+ * REST API Channel Controller class
+ */
+class Channel_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST endpoint.
+	 *
+	 * @type string
+	 */
+	const NAMESPACE = 'wp-notifications/v1';
+
+	/**
+	 * Base for channel REST routes.
+	 *
+	 * @type string
+	 */
+	public const NOTIFICATION_BASE = 'channels';
+
+	/**
+	 * Register REST routes
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			self::NOTIFICATION_BASE,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'args'                => $this->get_collection_params(),
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			),
+			false
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to view channels.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has access to view the items, error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_notifications_login_required',
+				__( 'Sorry, you must be logged to view channels.' ),
+				array( 'status' => 401 )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Get channels for request.
+	 *
+	 * @param WP_REST_Request $request Received REST request
+	 *
+	 * @return WP_REST_RESPONSE|WP_Error REST response or WP Error
+	 */
+	public function get_items( $request ) {
+		$channels = Channel_Registry::get_instance()->get_all_registered();
+
+		// TODO filter based on permissions.
+
+		return rest_ensure_response( $channels );
+	}
+
+	/**
+	 * Retrieves the channels's schema, conforming to JSON Schema.
+	 *
+	 * @return array The notification channel schema.
+	 */
+	public function get_item_schema(): array {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'notification',
+			'type'       => 'object',
+			'properties' => array(
+				'context' => array(
+					'description' => __( 'The default view context the notification channel.' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'embed' ),
+					'enum'        => array(
+						'adminbar',
+						'dashboard',
+					),
+					'readonly'    => true,
+				),
+				'icon'    => array(
+					'description' => __( 'The default icon of the notification channel.' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'embed' ),
+					'readonly'    => true,
+				),
+				'name'    => array(
+					'description' => __( 'Unique identifier for the notification channel.' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'embed' ),
+					'readonly'    => true,
+				),
+				'title'   => array(
+					'description' => __( 'The human-readable label of the notification channel.' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'embed' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		// Cache generated schema on endpoint instance.
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+
+	/**
+	 * Retrieves the query params for collections.
+	 *
+	 * @return array Comments collection parameters.
+	 */
+	public function get_collection_params(): array {
+		$query_params = parent::get_collection_params();
+
+		$query_params['context']['default'] = 'view';
+
+		$query_params['offset'] = array(
+			'description' => __( 'Offset the result set by a specific number of items.' ),
+			'type'        => 'integer',
+		);
+
+		$query_params['context'] = array(
+			'description' => __( 'Limit result set to channels assigned a specific display context.' ),
+			'default'     => 'all',
+			'type'        => 'string',
+		);
+
+		return $query_params;
+	}
+}

--- a/includes/restapi/class-notification-controller.php
+++ b/includes/restapi/class-notification-controller.php
@@ -140,7 +140,7 @@ class Notification_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 				),
 				'created_at'     => array(
-					'description' => __( "The datetime the notification was broadcast, in the site's timezone." ),
+					'description' => __( 'The datetime the notification was broadcast, in UTC time.' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'embed' ),
@@ -153,20 +153,20 @@ class Notification_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 				),
 				'dismissed_at'   => array(
-					'description' => __( "The datetime the notification was dismissed, in the site's timezone." ),
+					'description' => __( 'The datetime the notification was dismissed, in UTC time.' ),
 					'type'        => array( 'string', 'null' ),
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'embed' ),
 				),
 				'displayed_at'   => array(
-					'description' => __( "The datetime the notification was displayed, in the site's timezone." ),
+					'description' => __( 'The datetime the notification was displayed, in UTC time.' ),
 					'type'        => array( 'string', 'null' ),
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'embed' ),
 					'readonly'    => true,
 				),
 				'expires_at'     => array(
-					'description' => __( "The datetime the notification expires, in the site's timezone." ),
+					'description' => __( 'The datetime the notification expires, in UTC time.' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'embed' ),
@@ -226,6 +226,12 @@ class Notification_Controller extends WP_REST_Controller {
 					'context'     => array( 'view', 'embed' ),
 					'readonly'    => true,
 				),
+				'user_id'        => array(
+					'description' => __( 'The identifier of user the notification is belongs to.' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'embed' ),
+					'readonly'    => true,
+				),
 			),
 		);
 
@@ -238,7 +244,7 @@ class Notification_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves the query params for collections.
 	 *
-	 * @return array Comments collection parameters.
+	 * @return array Notifications collection parameters.
 	 */
 	public function get_collection_params(): array {
 		$query_params = parent::get_collection_params();

--- a/includes/restapi/class-notification-controller.php
+++ b/includes/restapi/class-notification-controller.php
@@ -32,10 +32,6 @@ class Notification_Controller extends WP_REST_Controller {
 	 */
 	public const NOTIFICATION_BASE = 'notifications';
 
-	public function __construct() {
-		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-	}
-
 	/**
 	 * Register REST routes
 	 *
@@ -173,6 +169,12 @@ class Notification_Controller extends WP_REST_Controller {
 					'description' => __( "The datetime the notification expires, in the site's timezone." ),
 					'type'        => 'string',
 					'format'      => 'date-time',
+					'context'     => array( 'view', 'embed' ),
+					'readonly'    => true,
+				),
+				'icon'           => array(
+					'description' => __( 'The icon of the notification.' ),
+					'type'        => 'integer',
 					'context'     => array( 'view', 'embed' ),
 					'readonly'    => true,
 				),

--- a/tests/phpunit/tests/rest-api/test-channel-controller.php
+++ b/tests/phpunit/tests/rest-api/test-channel-controller.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Unit tests covering WP/Notifications/Notification_Controller functionality.
+ * Unit tests covering WP/Notifications/Channel_Controller functionality.
  */
-class WP_Test_REST_Notification_Controller extends WP_Test_REST_Controller_Testcase {
+class WP_Test_REST_Channel_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_register_routes() {
 		$this->markTestSkipped( 'TODO Implement' );
 	}
@@ -36,49 +36,32 @@ class WP_Test_REST_Notification_Controller extends WP_Test_REST_Controller_Testc
 	}
 
 	public function test_registered_query_params() {
-		$request  = new WP_REST_Request( 'OPTIONS', '/wp-notifications/v1/notifications' );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp-notifications/v1/channels' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$keys     = array_keys( $data['endpoints'][0]['args'] );
 		sort( $keys );
 		$this->assertSame(
 			array(
-				'channel',
 				'context',
 				'offset',
-				'order',
-				'orderby',
 				'page',
 				'per_page',
 				'search',
-				'status',
 			),
 			$keys
 		);
 	}
 
 	public function test_get_item_schema() {
-		$request    = new WP_REST_Request( 'OPTIONS', '/wp-notifications/v1/notifications' );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp-notifications/v1/channels' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 17, $properties );
-		$this->assertArrayHasKey( 'accept_label', $properties );
-		$this->assertArrayHasKey( 'accept_link', $properties );
-		$this->assertArrayHasKey( 'channel_name', $properties );
-		$this->assertArrayHasKey( 'channel_title', $properties );
+		$this->assertCount( 4, $properties );
 		$this->assertArrayHasKey( 'context', $properties );
-		$this->assertArrayHasKey( 'created_at', $properties );
-		$this->assertArrayHasKey( 'dismiss_label', $properties );
-		$this->assertArrayHasKey( 'dismissed_at', $properties );
-		$this->assertArrayHasKey( 'displayed_at', $properties );
-		$this->assertArrayHasKey( 'expires_at', $properties );
 		$this->assertArrayHasKey( 'icon', $properties );
-		$this->assertArrayHasKey( 'id', $properties );
-		$this->assertArrayHasKey( 'is_dismissible', $properties );
-		$this->assertArrayHasKey( 'message', $properties );
-		$this->assertArrayHasKey( 'severity', $properties );
-		$this->assertArrayHasKey( 'status', $properties );
+		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
 	}
 }

--- a/tests/phpunit/tests/rest-api/test-subscription-controller.php
+++ b/tests/phpunit/tests/rest-api/test-subscription-controller.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Unit tests covering WP/Notifications/Notification_Controller functionality.
+ * Unit tests covering WP/Notifications/Subscription_Controller functionality.
  */
-class WP_Test_REST_Notification_Controller extends WP_Test_REST_Controller_Testcase {
+class WP_Test_REST_Subscription_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_register_routes() {
 		$this->markTestSkipped( 'TODO Implement' );
 	}
@@ -36,14 +36,13 @@ class WP_Test_REST_Notification_Controller extends WP_Test_REST_Controller_Testc
 	}
 
 	public function test_registered_query_params() {
-		$request  = new WP_REST_Request( 'OPTIONS', '/wp-notifications/v1/notifications' );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp-notifications/v1/subscriptions' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$keys     = array_keys( $data['endpoints'][0]['args'] );
 		sort( $keys );
 		$this->assertSame(
 			array(
-				'channel',
 				'context',
 				'offset',
 				'order',
@@ -51,35 +50,20 @@ class WP_Test_REST_Notification_Controller extends WP_Test_REST_Controller_Testc
 				'page',
 				'per_page',
 				'search',
-				'status',
 			),
 			$keys
 		);
 	}
 
 	public function test_get_item_schema() {
-		$request    = new WP_REST_Request( 'OPTIONS', '/wp-notifications/v1/notifications' );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp-notifications/v1/subscriptions' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 18, $properties );
-		$this->assertArrayHasKey( 'accept_label', $properties );
-		$this->assertArrayHasKey( 'accept_link', $properties );
+		$this->assertCount( 4, $properties );
 		$this->assertArrayHasKey( 'channel_name', $properties );
-		$this->assertArrayHasKey( 'channel_title', $properties );
-		$this->assertArrayHasKey( 'context', $properties );
 		$this->assertArrayHasKey( 'created_at', $properties );
-		$this->assertArrayHasKey( 'dismiss_label', $properties );
-		$this->assertArrayHasKey( 'dismissed_at', $properties );
-		$this->assertArrayHasKey( 'displayed_at', $properties );
-		$this->assertArrayHasKey( 'expires_at', $properties );
-		$this->assertArrayHasKey( 'icon', $properties );
-		$this->assertArrayHasKey( 'id', $properties );
-		$this->assertArrayHasKey( 'is_dismissible', $properties );
-		$this->assertArrayHasKey( 'message', $properties );
-		$this->assertArrayHasKey( 'severity', $properties );
-		$this->assertArrayHasKey( 'status', $properties );
-		$this->assertArrayHasKey( 'title', $properties );
+		$this->assertArrayHasKey( 'snoozed_until', $properties );
 		$this->assertArrayHasKey( 'user_id', $properties );
 	}
 }

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -59,6 +59,7 @@ require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/persistence/interfa
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/persistence/class-abstract-notification-repository.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/persistence/class-wpdb-notification-repository.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/demo.php';
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/restapi/class-channel-controller.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/restapi/class-notification-controller.php';
 
 new REST\Notification_Controller();
@@ -67,8 +68,6 @@ new REST\Notification_Controller();
  * Activation hook function of the WP Notification plugin.
  *
  * @return void
- *
- * @package wp-feature-notifications
  */
 function activation_hook() {
 	require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-activator.php';
@@ -81,8 +80,6 @@ register_activation_hook( __FILE__, '\WP\Notifications\activation_hook' );
  * Uninstall hook function of the WP Notification plugin.
  *
  * @return void
- *
- * @package wp-feature-notifications
  */
 function uninstall_hook() {
 	require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/class-uninstaller.php';
@@ -91,4 +88,17 @@ function uninstall_hook() {
 
 register_uninstall_hook( __FILE__, '\WP\Notifications\uninstall_hook' );
 
-new REST\Notification_Controller();
+/**
+ * REST API initialization hook of the WP Notification plugin.
+ *
+ * @return void
+ */
+function register_routes() {
+	$channel_controller      = new REST\Channel_Controller();
+	$notification_controller = new REST\Notification_Controller();
+
+	$channel_controller->register_routes();
+	$notification_controller->register_routes();
+}
+
+add_action( 'rest_api_init', '\WP\Notifications\register_routes' );

--- a/wp-feature-notifications.php
+++ b/wp-feature-notifications.php
@@ -61,8 +61,7 @@ require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/persistence/class-w
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/demo.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/restapi/class-channel-controller.php';
 require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/restapi/class-notification-controller.php';
-
-new REST\Notification_Controller();
+require_once WP_FEATURE_NOTIFICATION_PLUGIN_DIR . '/includes/restapi/class-subscription-controller.php';
 
 /**
  * Activation hook function of the WP Notification plugin.
@@ -96,9 +95,12 @@ register_uninstall_hook( __FILE__, '\WP\Notifications\uninstall_hook' );
 function register_routes() {
 	$channel_controller      = new REST\Channel_Controller();
 	$notification_controller = new REST\Notification_Controller();
+	$subscription_controller = new REST\Subscription_Controller();
 
 	$channel_controller->register_routes();
 	$notification_controller->register_routes();
+	$subscription_controller->register_routes();
+
 }
 
 add_action( 'rest_api_init', '\WP\Notifications\register_routes' );


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add an initial channel rest controller.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

To allow fetching a list of all available notification channels in the client.

**Additionally**

- Reorganized the initialization of the rest controllers.
- Added tests for the `Channel_Controller` schema.
- Added a missing `icon` schema property to the `Notification_Controller`