### PR TITLE
refactor: initially render bell icon server side

### DIFF
--- a/includes/load.php
+++ b/includes/load.php
@@ -65,7 +65,7 @@ function admin_bar_item( WP_Admin_Bar $wp_admin_bar ) {
 	 * If this is changed that file must also be updated.
 	 */
 	$notification_hub_icon = sprintf(
-		'<div class="notifications"><button class="hub-icon" aria-haspopup="menu"><span class="ab-icon dashicons dashicons-bell" aria-hidden="true"></span><span class="ab-label screen-reader-text">%s</span></button></div>',
+		'<div class="notifications"><button class="hub-icon" aria-haspopup="menu"><span class="ab-icon dashicons dashicons-bell" aria-hidden="true"></span><span class="ab-label screen-reader-text">%s</span><span class="unread-dot"></span></button></div>',
 		__( 'Notifications', 'wp-feature-notifications' )
 	);
 

--- a/includes/load.php
+++ b/includes/load.php
@@ -51,12 +51,31 @@ function admin_bar_item( WP_Admin_Bar $wp_admin_bar ) {
 		return;
 	}
 
+	/**
+	 * This is the same HTML as the `src/scripts/components/NotificationHub.js`
+	 * If this is changed that file must also be updated.
+	 */
+	$notification_hub = sprintf(
+		'<aside id="wp-notifications-hub"><div class="hub-wrapper"><h2 class="screen-reader-text">%s</h2></div></aside>',
+		__( 'Notifications', 'wp-feature-notifications' )
+	);
+
+	/**
+	 * This is the same HTML as the `src/scripts/components/NotificationHubIcon.js`
+	 * If this is changed that file must also be updated.
+	 */
+	$notification_hub_icon = sprintf(
+		'<div class="notifications"><button class="hub-icon" aria-haspopup="menu"><span class="ab-icon dashicons dashicons-bell" aria-hidden="true"></span><span class="ab-label">%s</span></button></div>',
+		__( 'Notifications', 'wp-feature-notifications' )
+	);
+
 	$args = array(
 		'id'     => 'wp-notifications-hub',
-		'title'  => __( 'loading' ),
 		'parent' => 'top-secondary',
+		'title'  => $notification_hub_icon,
 		'meta'   => array(
 			'tabindex' => 0,
+			'html'     => $notification_hub,
 		),
 	);
 	$wp_admin_bar->add_node( $args );

--- a/includes/load.php
+++ b/includes/load.php
@@ -65,7 +65,7 @@ function admin_bar_item( WP_Admin_Bar $wp_admin_bar ) {
 	 * If this is changed that file must also be updated.
 	 */
 	$notification_hub_icon = sprintf(
-		'<div class="notifications"><button class="hub-icon" aria-haspopup="menu"><span class="ab-icon dashicons dashicons-bell" aria-hidden="true"></span><span class="ab-label">%s</span></button></div>',
+		'<div class="notifications"><button class="hub-icon" aria-haspopup="menu"><span class="ab-icon dashicons dashicons-bell" aria-hidden="true"></span><span class="ab-label screen-reader-text">%s</span></button></div>',
 		__( 'Notifications', 'wp-feature-notifications' )
 	);
 

--- a/src/scripts/components/NotificationHub.js
+++ b/src/scripts/components/NotificationHub.js
@@ -63,8 +63,8 @@ export const NotificationHub = ( { initialActive = false } ) => {
 	}, [ isActive ] );
 
 	return (
-		<div className="ab-item ab-empty-item" tabIndex={ 0 }>
-			<ShortcutProvider
+		<ShortcutProvider className="ab-item ab-empty-item" tabIndex={ 0 }>
+			<div
 				className={ classNames( [
 					'notifications',
 					isActive ? 'active' : '',
@@ -79,7 +79,7 @@ export const NotificationHub = ( { initialActive = false } ) => {
 					focus={ () => setIsActive( true ) }
 					blur={ () => setIsActive( false ) }
 				/>
-			</ShortcutProvider>
-		</div>
+			</div>
+		</ShortcutProvider>
 	);
 };

--- a/src/scripts/components/NotificationHub.js
+++ b/src/scripts/components/NotificationHub.js
@@ -73,6 +73,7 @@ export const NotificationHub = ( { initialActive = false } ) => {
 				<NotificationHubIcon
 					toggle={ toggleDrawer }
 					isActive={ isActive }
+					hasUnread={ true }
 				/>
 				<Drawer
 					instance={ drawerRef }

--- a/src/scripts/components/NotificationHub.js
+++ b/src/scripts/components/NotificationHub.js
@@ -11,6 +11,12 @@ import { Drawer } from './Drawer';
 import { NotificationHubIcon } from './NotificationHubIcon';
 
 /**
+ * The HTML rendered by this component is the same as the variable `notification_hub`
+ * in`includes/load.php`. If the output of this component is modified that file must
+ * also be updated.
+ */
+
+/**
  * The notification hub component.
  *
  * @param {Object}   props               Properties
@@ -57,21 +63,23 @@ export const NotificationHub = ( { initialActive = false } ) => {
 	}, [ isActive ] );
 
 	return (
-		<ShortcutProvider
-			className={ classNames( [
-				'notifications',
-				isActive ? 'active' : '',
-			] ) }
-		>
-			<NotificationHubIcon
-				toggle={ toggleDrawer }
-				isActive={ isActive }
-			/>
-			<Drawer
-				instance={ drawerRef }
-				focus={ () => setIsActive( true ) }
-				blur={ () => setIsActive( false ) }
-			/>
-		</ShortcutProvider>
+		<div className="ab-item ab-empty-item" tabIndex={ 0 }>
+			<ShortcutProvider
+				className={ classNames( [
+					'notifications',
+					isActive ? 'active' : '',
+				] ) }
+			>
+				<NotificationHubIcon
+					toggle={ toggleDrawer }
+					isActive={ isActive }
+				/>
+				<Drawer
+					instance={ drawerRef }
+					focus={ () => setIsActive( true ) }
+					blur={ () => setIsActive( false ) }
+				/>
+			</ShortcutProvider>
+		</div>
 	);
 };

--- a/src/scripts/components/NotificationHub.js
+++ b/src/scripts/components/NotificationHub.js
@@ -73,7 +73,6 @@ export const NotificationHub = ( { initialActive = false } ) => {
 				<NotificationHubIcon
 					toggle={ toggleDrawer }
 					isActive={ isActive }
-					hasUnread={ true }
 				/>
 				<Drawer
 					instance={ drawerRef }

--- a/src/scripts/components/NotificationHubIcon.js
+++ b/src/scripts/components/NotificationHubIcon.js
@@ -39,7 +39,9 @@ export const NotificationHubIcon = ( {
 				className={ classNames( 'ab-icon', 'dashicons', ...classes ) }
 				aria-hidden="true"
 			></span>
-			<span className={ 'ab-label' }>{ __( 'Notifications' ) }</span>
+			<span className="ab-label screen-reader-text">
+				{ __( 'Notifications' ) }
+			</span>
 		</button>
 	);
 };

--- a/src/scripts/components/NotificationHubIcon.js
+++ b/src/scripts/components/NotificationHubIcon.js
@@ -3,6 +3,12 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import classNames from 'classnames';
 
 /**
+ * The HTML rendered by this component is the same as the variable `notification_hub_icon`
+ * in`includes/load.php`. If the output of this component is modified that file must
+ * also be updated.
+ */
+
+/**
  * Notification icon UI component
  *
  * @param {Object}    Props
@@ -25,7 +31,7 @@ export const NotificationHubIcon = ( {
 
 	return (
 		<button
-			className={ 'ab-item' }
+			className={ 'hub-icon' }
 			aria-haspopup="menu"
 			onClick={ () => toggle() }
 		>

--- a/src/scripts/components/NotificationHubIcon.js
+++ b/src/scripts/components/NotificationHubIcon.js
@@ -12,14 +12,16 @@ import classNames from 'classnames';
  * Notification icon UI component
  *
  * @param {Object}    Props
- * @param {Function}  Props.toggle   Toggle the drawer on and off.
- * @param {boolean}   Props.isActive Predicate of whether the drawer is in an active state.
- * @param {string[]=} Props.classes  The icon class names (defaults to [ 'dashicons-bell' ])
+ * @param {Function}  Props.toggle    Toggle the drawer on and off.
+ * @param {boolean}   Props.isActive  Predicate of whether the drawer is in an active state.
+ * @param {boolean=}  Props.hasUnread Predicate of whether there are unread notifications.
+ * @param {string[]=} Props.classes   The icon class names (defaults to [ 'dashicons-bell' ])
  * @return {JSX.Element} - the Notification icon
  */
 export const NotificationHubIcon = ( {
 	toggle,
 	isActive,
+	hasUnread = false,
 	classes = [ 'dashicons-bell' ],
 } ) => {
 	/**
@@ -42,6 +44,12 @@ export const NotificationHubIcon = ( {
 			<span className="ab-label screen-reader-text">
 				{ __( 'Notifications' ) }
 			</span>
+			<span
+				className={ classNames(
+					'unread-dot',
+					hasUnread ? 'has-unread' : ''
+				) }
+			></span>
 		</button>
 	);
 };

--- a/src/styles/hub/admin-bar.scss
+++ b/src/styles/hub/admin-bar.scss
@@ -55,12 +55,12 @@
 		border: 1px solid $color-black-800;
 
 		/* initially it is hidden */
-		opacity: 0%;
+		opacity: 0;
 
 		transition: opacity 0.175s;
 
 		&.has-unread {
-			opacity: 100%;
+			opacity: 1;
 		}
 	}
 

--- a/src/styles/hub/admin-bar.scss
+++ b/src/styles/hub/admin-bar.scss
@@ -18,18 +18,17 @@
 	}
 
 	/* the bell icon */
-	.ab-item {
+	.hub-icon {
 		appearance: none;
 		height: 32px;
 		display: block;
-		padding: 0 10px;
 		border: 0;
 		margin: 0;
 		background: none;
 	}
 
 	/* if the drawer is enabled transforms the bell icon to overlay the drawer */
-	.notifications.active > .ab-item .ab-icon {
+	.notifications.active > .hub-icon .ab-icon {
 		filter: invert(1) hue-rotate(180deg);
 		position: relative;
 		z-index: 100002;

--- a/src/styles/hub/admin-bar.scss
+++ b/src/styles/hub/admin-bar.scss
@@ -35,7 +35,7 @@
 	}
 
 	/* The label is the red dot over the bell */
-	.ab-label {
+	.has-new-notifications {
 		position: absolute;
 		width: 6px;
 		height: 6px;
@@ -55,7 +55,7 @@
 	@media #{$breakpoint} {
 		display: block;
 
-		.ab-label {
+		.has-new-notifications {
 			clip: unset;
 			clip-path: unset;
 			width: 11px;

--- a/src/styles/hub/admin-bar.scss
+++ b/src/styles/hub/admin-bar.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable font-family-no-missing-generic-family-keyword */
+
 /*
  * WP admin bar
  */
@@ -20,11 +22,13 @@
 	/* the bell icon */
 	.hub-icon {
 		appearance: none;
+		width: 28px;
 		height: 32px;
 		display: block;
 		border: 0;
 		margin: 0;
 		background: none;
+
 	}
 
 	/* if the drawer is enabled transforms the bell icon to overlay the drawer */
@@ -34,8 +38,8 @@
 		z-index: 100002;
 	}
 
-	/* The label is the red dot over the bell */
-	.has-new-notifications {
+	/* The red dot over the bell */
+	.unread-dot {
 		position: absolute;
 		width: 6px;
 		height: 6px;
@@ -49,17 +53,36 @@
 
 		/* the dot color border */
 		border: 1px solid $color-black-800;
+
+		/* initially it is hidden */
+		opacity: 0%;
+
+		transition: opacity 0.175s;
+
+		&.has-unread {
+			opacity: 100%;
+		}
 	}
 
 	/* Mobile */
 	@media #{$breakpoint} {
 		display: block;
 
-		.has-new-notifications {
+		.hub-icon {
+			width: 54px;
+			height: 46px;
+
+			.ab-icon {
+				padding-top: 6px;
+				font: 32px/1 dashicons !important;
+			}
+		}
+
+		.unread-dot {
 			clip: unset;
 			clip-path: unset;
-			width: 11px;
-			height: 11px;
+			width: 9px;
+			height: 9px;
 			top: 16px;
 			left: 28px;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Render the bell icon on the server.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

The bell icon would appear after the JavaScript loaded and cause the icon to jump on every page transition. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

@erikyo helped me with the code required to render the bell in the admin bar.

## TODO

- [x] The bell icon initially renders a little high and adjusts once the React component is rendered. Some style that is applied on the client isn't in the PHP code.
