### PR TITLE
Feature: Notification polling on the client

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,0 +1,46 @@
+export class Poller {
+	/**
+	 * On pages like the post editor or post list, the heartbeat is fired right at the beginning
+	 * of the page load. We already fetched the notifications on page load, so this would result
+	 * in a duplicate request. To prevent this, we skip the first heartbeat tick for the first X seconds.
+	 */
+	SKIP_FIRST_INTERVAL = 5000;
+	public skipFirstBeat = true;
+
+	constructor( shouldSkipFirstBeat = true ) {
+		this.skipFirstBeat = shouldSkipFirstBeat;
+	}
+
+	public pollUpdates() {
+		if ( this.skipFirstBeat ) {
+			return;
+		}
+		window.wp.notifications.fetchUpdates( true );
+	}
+
+	public unsetSkipFirstBeat() {
+		setTimeout( () => {
+			this.skipFirstBeat = false;
+		}, this.SKIP_FIRST_INTERVAL );
+	}
+
+	public start() {
+		if ( this.skipFirstBeat ) {
+			this.unsetSkipFirstBeat();
+		}
+
+		wp.hooks.addAction(
+			'heartbeat.tick',
+			'wp-notifications/pollUpdates',
+			this.pollUpdates.bind( this )
+		);
+	}
+
+	public stop() {
+		wp.hooks.removeAction(
+			'heartbeat.tick',
+			'wp-notifications/pollUpdates',
+			this.pollUpdates.bind( this )
+		);
+	}
+}

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -13,6 +13,13 @@ export const hydrate = ( payload: Notice[] ) => {
 	};
 };
 
+export const rehydrate = ( payload: Notice[] ) => {
+	return {
+		type: 'REHYDRATE' as const,
+		payload,
+	};
+};
+
 /**
  * Action creator to clear a notification context from the store.
  *

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -24,6 +24,38 @@ const reducer: Reducer< State, Action > = ( state = {}, action ) => {
 			} );
 			return updated;
 		}
+		case 'REHYDRATE': {
+			let updated = { ...state };
+			// Merge the new notifications with the existing ones.
+			action.payload.forEach( ( notification ) => {
+				const context = notification.context || 'adminbar';
+
+				const existingOnes = updated[ context ] || [];
+				const existing = existingOnes.findIndex(
+					( notice ) => notice.id === notification.id
+				);
+
+				if ( existing > -1 ) {
+					updated[ context ][ existing ] = notification;
+				} else {
+					updated = {
+						...updated,
+						[ context ]: [ ...updated[ context ], notification ],
+					};
+				}
+			} );
+
+			// Remove any notifications that are no longer in the payload.
+			for ( const context in updated ) {
+				updated[ context ] = updated[ context ].filter( ( notice ) => {
+					return action.payload.find( ( payloadNotice ) => {
+						return payloadNotice.id === notice.id;
+					} );
+				} );
+			}
+
+			return updated;
+		}
 		case 'ADD': {
 			return {
 				...state,

--- a/src/store/resolvers.ts
+++ b/src/store/resolvers.ts
@@ -1,12 +1,16 @@
-import { fetchAPI, hydrate } from './actions';
+import { fetchAPI, hydrate, rehydrate } from './actions';
 
 /**
  * Fetch the rest api in order to get new notifications
+ *
+ * @param force
  */
-export const fetchUpdates = function* () {
+export const fetchUpdates = function* ( force = false ) {
 	const newNotifications = yield fetchAPI();
 
+	const action = force ? rehydrate : hydrate;
+
 	if ( newNotifications ) {
-		return hydrate( newNotifications );
+		return action( newNotifications );
 	}
 };

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -10,9 +10,11 @@ import type { State } from './index';
  * Fetch the rest api in order to get new notifications
  *
  * @param state the current state
+ * @param force
  * @return the new notifications
  */
-export const fetchUpdates = ( state: State ): State => state || {};
+export const fetchUpdates = ( state: State, force = false ): State =>
+	state || {};
 
 /**
  * Get the notices for the given context


### PR DESCRIPTION
## What?
This PR adds notification polling, currently based on the heartbeat API from WordPress.

## Why?
This attempts to solve the following issue: https://github.com/WordPress/wp-feature-notifications/issues/306

## How?
This PR adds a new Poller class that abstracts how/when/how often the notifications are polled.
It makes sense to use the existing Heartbeat API from WordPress since it is reliable. The Heartbeat API is a simple server polling API built into WordPress, allowing near-real-time frontend updates. 
[Heartbeat API Docs](https://developer.wordpress.org/plugins/javascript/heartbeat-api/)

The Poller class hooks into the `heartbeat.tick` event, which is triggered on a successful heartbeat (in case the user session expired or there is another error, we also skip useless polls to the API).

There is a parameter that is passed to the Poller class named `shouldSkipFirstBeat` which solves the following edge-case: we load all notifications on page load, but also on some pages, the heartbeat API runs very early on the page load (eg: on post edit/create screen, on post list).
To avoid double, repeated polls to fetch notifications, the first `Poller.SKIP_FIRST_INTERVAL` milliseconds, any heartbeat tick events are ignored.

The Poller instance is added to the `notifications` (`window.wp.notifications`) object, so you can easily do:
 - `window.wp.notifications.poller.stop()` - Stop polling
 - `window.wp.notifications.poller.start()` - Start/resume polling

## Testing Instructions
1. Visit any page on `wp-admin`
2. Wait for a heartbeat tick event
3. Notice the polling request.
4. Visit the posts page. Check that only one call is made on page load.

I am open to suggestions and ideas, also if you want to use a setInterval/setTimeout instead of the Heartbeats API, let pe know. I think it is appropriate though.

Closes #306 
