### PR TITLE
Update dependabot config to use grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
           prefix: 'Composer'
       allow:
           - dependency-type: 'direct'
+      groups:
+          phpunit:
+              patterns:
+                  - 'phpunit/phpunit'
+                  - 'wp-phpunit/wp-phpunit'
 
     - package-ecosystem: 'npm'
       directory: '/'
@@ -26,3 +31,7 @@ updates:
           - dependency-type: 'direct'
           - dependency-name: '@wordpress/*'
             dependency-type: 'all'
+      groups:
+          wordpress:
+              patterns:
+                  - '@wordpress/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
               patterns:
                   - 'phpunit/phpunit'
                   - 'wp-phpunit/wp-phpunit'
+                  - 'yoast/phpunit-polyfills'
 
     - package-ecosystem: 'npm'
       directory: '/'

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.6",
-		"yoast/phpunit-polyfills": "1.0.5",
+		"yoast/phpunit-polyfills": "^1.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"wp-coding-standards/wpcs": "^2.3",
 		"wp-phpunit/wp-phpunit": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9a58530f931316fe8917362126f3ac4",
+    "content-hash": "b57ebed0475ac0c9db7ac3972197ee4c",
     "packages": [],
     "packages-dev": [
         {
@@ -4072,16 +4072,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -4128,7 +4128,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -4143,5 +4143,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Dependabot now supports grouping of PRs based on patterns https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

This should make update much less tedious and much easier to manage.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

It's important to keep on top of updates, however we currently have a huge number of pull requests being generated by Dependabot, which are not easy to keep on top of.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've added some grouping as follows:

- All `@wordpress/*` npm updates should be grouped
- All phpunit Composer updates should be grouped

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
