### PR TITLE
Add storybook grouping for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,6 @@ updates:
           wordpress:
               patterns:
                   - '@wordpress/*'
+          storybook:
+              patterns:
+                - '@storybook/*'


### PR DESCRIPTION
<!-- Thanks for contributing to WP Feature Notifications! Please follow the Contributing Guidelines:
https://github.com/WordPress/wp-feature-notifications/wiki/Code-contributions -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a new group for Dependabot to group Storybook dependencies

## Why?
<!-- Why is this PR necessary? What problem is it solving? Please add a short summary here and reference any existing previous issue(s) or PR(s):
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

There are multiple Storybook packages with updates, this should make this more maintainable and produce less noise.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Create a new group for npm dependencies under `@storybook/*`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
