### PR TITLE
Types: add return type declaration to jsonSerialize methods

### DIFF
--- a/includes/image/class-base-image.php
+++ b/includes/image/class-base-image.php
@@ -30,7 +30,7 @@ class Base_Image implements Image {
 	/**
 	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 
 		$data = array();
 

--- a/includes/model/class-channel.php
+++ b/includes/model/class-channel.php
@@ -84,7 +84,7 @@ class Channel implements JsonSerializable {
 	 * @return array Data which can be serialized by json_encode, which is a
 	 *               value of any type other than a resource.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return array(
 			'context'     => $this->context,
 			'description' => $this->description,

--- a/includes/model/class-message.php
+++ b/includes/model/class-message.php
@@ -155,7 +155,7 @@ class Message implements JsonSerializable {
 	 * @return array Data which can be serialized by json_encode, which is a
 	 *               value of any type other than a resource.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return array_merge(
 			$this->collect_meta(),
 			array(

--- a/includes/model/class-notification.php
+++ b/includes/model/class-notification.php
@@ -108,7 +108,7 @@ class Notification implements JsonSerializable {
 	 * @return array Data which can be serialized by json_encode, which is a
 	 *               value of any type other than a resource.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return array(
 			'channel_name' => $this->channel_name,
 			'context'      => $this->context,

--- a/includes/model/class-subscription.php
+++ b/includes/model/class-subscription.php
@@ -79,7 +79,7 @@ class Subscription implements JsonSerializable {
 	 * @return array Data which can be serialized by json_encode, which is a
 	 *               value of any type other than a resource.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return array(
 			'channel_name'  => $this->channel_name,
 			'created_at'    => Helper\Serde::maybe_serialize_json_date( $this->created_at ),


### PR DESCRIPTION
## What?
There are plenty of deprecation errors to be solved.

## Why?
`jsonSerialize` return types are missing